### PR TITLE
Improved BlackDuckRestConnection authentication

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/rest/BlackDuckRestConnection.java
+++ b/src/main/java/com/synopsys/integration/blackduck/rest/BlackDuckRestConnection.java
@@ -29,9 +29,11 @@ import java.net.URL;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.connection.ReconnectingRestConnection;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.request.Response;
 
 /**
  * A BlackDuckRestConnection will always decorate the provided RestConnection with a ReconnectingRestConnection
@@ -64,4 +66,6 @@ public abstract class BlackDuckRestConnection extends ReconnectingRestConnection
             return null;
         }
     }
+
+    public abstract Response attemptToAuthenticate() throws IntegrationException;
 }


### PR DESCRIPTION
Exposes a method for authenticating

I don't believe the following is too much of a burden on the end integration.
```
        final BlackDuckRestConnection blackDuckRestConnection = new ApiTokenRestConnection(null,300,true, ProxyInfo.NO_PROXY_INFO,"htttp://baseUrlStuff", "12345_apitoken");

        boolean authenticated = false;
        try (final Response response = blackDuckRestConnection.attemptToAuthenticate()) {
            authenticated = response.isStatusCodeOkay();
        } catch (IntegrationException | IOException ignored) {
            // Don't care
        }

        // Use authenticated variable here
```