### PR TITLE
fix(ComponentService) Fixed ComponentService::getExactComponentMatchnot matching against origin id's of different cases.

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/service/ComponentService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/ComponentService.java
@@ -78,7 +78,7 @@ public class ComponentService extends DataService {
         String originIdToMatch = externalId.createBlackDuckOriginId();
         for (ComponentSearchResultView componentItem : allComponents) {
             if (null != originIdToMatch) {
-                if (originIdToMatch.equals(componentItem.getOriginId())) {
+                if (originIdToMatch.equalsIgnoreCase(componentItem.getOriginId())) {
                     return Optional.of(componentItem);
                 }
             }

--- a/src/test/groovy/com/synopsys/integration/blackduck/api/ComponentServiceTestIT.java
+++ b/src/test/groovy/com/synopsys/integration/blackduck/api/ComponentServiceTestIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.synopsys.integration.bdio.SimpleBdioFactory;
+import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.blackduck.TimingExtension;
 import com.synopsys.integration.blackduck.api.generated.view.ComponentSearchResultView;
@@ -28,6 +29,18 @@ public class ComponentServiceTestIT {
         SimpleBdioFactory simpleBdioFactory = new SimpleBdioFactory();
 
         ExternalId integrationCommonExternalId = simpleBdioFactory.createMavenExternalId("com.blackducksoftware.integration", "integration-common", "15.0.0");
+        Optional<ComponentSearchResultView> componentView = componentService.getExactComponentMatch(integrationCommonExternalId);
+
+        assertTrue(componentView.isPresent());
+    }
+
+    @Test
+    public void testOriginIdMMismatch() throws Exception {
+        BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory();
+        ComponentService componentService = blackDuckServicesFactory.createComponentService();
+        SimpleBdioFactory simpleBdioFactory = new SimpleBdioFactory();
+
+        ExternalId integrationCommonExternalId = simpleBdioFactory.createNameVersionExternalId(Forge.PYPI, "cycler", "0.10.0");
         Optional<ComponentSearchResultView> componentView = componentService.getExactComponentMatch(integrationCommonExternalId);
 
         assertTrue(componentView.isPresent());


### PR DESCRIPTION
For components like Cycler 0.10.0, the library fails to find an exact component match when the origin id returned from Black Duck is a different case than the one searched for. 

Example:
Searched for "cycler/0.10.0"
Received "Cycler/0.10.0" 