### PR TITLE
Adding the Content-Length header

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/rest/ApiTokenBlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/rest/ApiTokenBlackDuckHttpClient.java
@@ -75,6 +75,8 @@ public class ApiTokenBlackDuckHttpClient extends BlackDuckHttpClient {
     public final Response attemptAuthentication() throws IntegrationException {
         Map<String, String> headers = new HashMap<>();
         headers.put(AuthenticationSupport.AUTHORIZATION_HEADER, "token " + apiToken);
+        // https://github.com/blackducksoftware/blackduck-common/issues/268
+        headers.put("Content-Length", "0");
 
         return authenticationSupport.attemptAuthentication(this, getBaseUrl(), "api/tokens/authenticate", headers);
     }


### PR DESCRIPTION
I added the Content-Length header as part of the API Token authentication. It was pointed out in https://github.com/blackducksoftware/blackduck-common/issues/268 that this is best practice in a POST request. See the GitHub issue for more details.