### PR TITLE
feat(service): Allows responses to be paged to a limit.

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckService.java
@@ -87,6 +87,14 @@ public class BlackDuckService {
         return gson;
     }
 
+    public BlackDuckResponseTransformer getBlackDuckResponseTransformer() {
+        return blackDuckResponseTransformer;
+    }
+
+    public BlackDuckResponsesTransformer getBlackDuckResponsesTransformer() {
+        return blackDuckResponsesTransformer;
+    }
+
     public <T extends BlackDuckResponse> T transformResponse(Response response, Class<T> clazz) throws IntegrationException {
         return blackDuckJsonTransformer.getResponse(response, clazz);
     }

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckService.java
@@ -128,13 +128,19 @@ public class BlackDuckService {
         return blackDuckResponsesTransformer.getResponses(new PagedRequest(requestBuilder), blackDuckPathMultipleResponses.getResponseClass(), getAll);
     }
 
+    public <T extends BlackDuckResponse> BlackDuckPageResponse<T> getPageResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses, int maxPageCount) throws IntegrationException {
+        String uri = pieceTogetherUri(blackDuckBaseUrl, blackDuckPathMultipleResponses.getBlackDuckPath().getPath());
+        Request.Builder requestBuilder = RequestFactory.createCommonGetRequestBuilder(uri);
+        return blackDuckResponsesTransformer.getResponses(new PagedRequest(requestBuilder), blackDuckPathMultipleResponses.getResponseClass(), maxPageCount);
+    }
+
     public <T extends BlackDuckResponse> List<T> getResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses, Request.Builder requestBuilder, boolean getAll)
-            throws IntegrationException {
+        throws IntegrationException {
         return getPageResponses(blackDuckPathMultipleResponses, requestBuilder, getAll).getItems();
     }
 
     public <T extends BlackDuckResponse> BlackDuckPageResponse<T> getPageResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses, Request.Builder requestBuilder, boolean getAll)
-            throws IntegrationException {
+        throws IntegrationException {
         String uri = pieceTogetherUri(blackDuckBaseUrl, blackDuckPathMultipleResponses.getBlackDuckPath().getPath());
         requestBuilder.uri(uri);
         return blackDuckResponsesTransformer.getResponses(new PagedRequest(requestBuilder), blackDuckPathMultipleResponses.getResponseClass(), getAll);
@@ -159,17 +165,37 @@ public class BlackDuckService {
         return getResponses(blackDuckView, linkMultipleResponses, true);
     }
 
+    public <T extends BlackDuckResponse> List<T> getAllResponses(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses, int maxPageCount) throws IntegrationException {
+        return getResponses(blackDuckView, linkMultipleResponses, maxPageCount);
+    }
+
     public <T extends BlackDuckResponse> List<T> getAllResponses(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses, Request.Builder requestBuilder) throws IntegrationException {
         return getResponses(blackDuckView, linkMultipleResponses, requestBuilder, true);
     }
 
     public <T extends BlackDuckResponse> List<T> getResponses(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses, boolean getAll) throws IntegrationException {
-        Optional<String> uri = blackDuckView.getFirstLink(linkMultipleResponses.getLink());
-        if (!uri.isPresent() || StringUtils.isBlank(uri.get())) {
+        final PagedRequest pagedRequest = createResponsesPagedRequest(blackDuckView, linkMultipleResponses);
+        if (pagedRequest == null) {
             return Collections.emptyList();
         }
+        return blackDuckResponsesTransformer.getResponses(pagedRequest, linkMultipleResponses.getResponseClass(), getAll).getItems();
+    }
+
+    public <T extends BlackDuckResponse> List<T> getResponses(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses, int maxPageCount) throws IntegrationException {
+        final PagedRequest pagedRequest = createResponsesPagedRequest(blackDuckView, linkMultipleResponses);
+        if (pagedRequest == null) {
+            return Collections.emptyList();
+        }
+        return blackDuckResponsesTransformer.getResponses(pagedRequest, linkMultipleResponses.getResponseClass(), maxPageCount).getItems();
+    }
+
+    private <T extends BlackDuckResponse> PagedRequest createResponsesPagedRequest(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses) {
+        Optional<String> uri = blackDuckView.getFirstLink(linkMultipleResponses.getLink());
+        if (!uri.isPresent() || StringUtils.isBlank(uri.get())) {
+            return null;
+        }
         Request.Builder requestBuilder = RequestFactory.createCommonGetRequestBuilder(uri.get());
-        return blackDuckResponsesTransformer.getResponses(new PagedRequest(requestBuilder), linkMultipleResponses.getResponseClass(), getAll).getItems();
+        return new PagedRequest(requestBuilder);
     }
 
     public <T extends BlackDuckResponse> List<T> getResponses(BlackDuckView blackDuckView, LinkMultipleResponses<T> linkMultipleResponses, Request.Builder requestBuilder, boolean getAll) throws IntegrationException {

--- a/src/test/groovy/com/synopsys/integration/blackduck/service/BlackDuckResponsesTransformerTest.java
+++ b/src/test/groovy/com/synopsys/integration/blackduck/service/BlackDuckResponsesTransformerTest.java
@@ -1,0 +1,85 @@
+package com.synopsys.integration.blackduck.service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.synopsys.integration.blackduck.TimingExtension;
+import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
+import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationException;
+import com.synopsys.integration.blackduck.rest.IntHttpClientTestHelper;
+import com.synopsys.integration.blackduck.service.model.PagedRequest;
+import com.synopsys.integration.blackduck.service.model.RequestFactory;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.request.Request;
+
+@Tag("integration")
+@ExtendWith(TimingExtension.class)
+class BlackDuckResponsesTransformerTest {
+
+    private final IntHttpClientTestHelper intHttpClientTestHelper = new IntHttpClientTestHelper();
+    private final BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory();
+
+    BlackDuckResponsesTransformerTest() throws IntegrationException {}
+
+    @Test
+    void getAllResponses() throws IntegrationException {
+        final BlackDuckResponsesTransformer blackDuckResponsesTransformer = createBlackDuckResponsesTransformer();
+        final Request.Builder requestBuilder = createRequestBuilder();
+
+        final PagedRequest defaultPagedRequest = new PagedRequest(requestBuilder);
+        final BlackDuckPageResponse<ProjectView> responses = blackDuckResponsesTransformer.getAllResponses(defaultPagedRequest, ApiDiscovery.PROJECTS_LINK_RESPONSE.getResponseClass());
+        Assertions.assertEquals(responses.getTotalCount(), responses.getItems().size());
+    }
+
+    @Test
+    void getResponsesWithAll() throws IntegrationException {
+        final BlackDuckResponsesTransformer blackDuckResponsesTransformer = createBlackDuckResponsesTransformer();
+        final Request.Builder requestBuilder = createRequestBuilder();
+
+        final PagedRequest defaultPagedRequest = new PagedRequest(requestBuilder);
+        final BlackDuckPageResponse<ProjectView> responses = blackDuckResponsesTransformer.getResponses(defaultPagedRequest, ApiDiscovery.PROJECTS_LINK_RESPONSE.getResponseClass(), true);
+        Assertions.assertEquals(responses.getTotalCount(), responses.getItems().size());
+
+        final PagedRequest limitedPagedRequest = new PagedRequest(requestBuilder, 0, 2);
+        final BlackDuckPageResponse<ProjectView> limitedResponses = blackDuckResponsesTransformer.getResponses(limitedPagedRequest, ApiDiscovery.PROJECTS_LINK_RESPONSE.getResponseClass(), false);
+        Assertions.assertNotEquals(limitedResponses.getTotalCount(), limitedResponses.getItems().size(), "Too many projects were returned. Note: Black Duck must have more than 2 projects for this test to pass.");
+    }
+
+    @Test
+    void testGetResponsesWithMaxPageCount() throws IntegrationException {
+        final BlackDuckResponsesTransformer blackDuckResponsesTransformer = createBlackDuckResponsesTransformer();
+        final Request.Builder requestBuilder = createRequestBuilder();
+
+        final PagedRequest limitedPagedRequest = new PagedRequest(requestBuilder, 0, 2);
+        final BlackDuckPageResponse<ProjectView> limitedResponses = blackDuckResponsesTransformer.getResponses(limitedPagedRequest, ApiDiscovery.PROJECTS_LINK_RESPONSE.getResponseClass(), 2);
+        Assertions.assertEquals(4, limitedResponses.getItems().size(), "Too many projects were returned. Note: Black Duck must have more than 4 projects for this test to pass.");
+    }
+
+    private Request.Builder createRequestBuilder() throws BlackDuckIntegrationException {
+        final String blackDuckBaseUrl = blackDuckServicesFactory.createBlackDuckService().getBlackDuckBaseUrl();
+        final String uri = pieceTogetherUri(blackDuckBaseUrl, ApiDiscovery.PROJECTS_LINK_RESPONSE.getBlackDuckPath().getPath());
+        return RequestFactory.createCommonGetRequestBuilder(uri);
+    }
+
+    private BlackDuckResponsesTransformer createBlackDuckResponsesTransformer() throws IntegrationException {
+        final BlackDuckJsonTransformer blackDuckJsonTransformer = new BlackDuckJsonTransformer(blackDuckServicesFactory.getGson(), blackDuckServicesFactory.getObjectMapper(), blackDuckServicesFactory.getLogger());
+        return new BlackDuckResponsesTransformer(blackDuckServicesFactory.getBlackDuckHttpClient(), blackDuckJsonTransformer);
+    }
+
+    private String pieceTogetherUri(String baseUrl, String spec) throws BlackDuckIntegrationException {
+        URL url;
+        try {
+            URL baseURL = new URL(baseUrl);
+            url = new URL(baseURL, spec);
+        } catch (MalformedURLException e) {
+            throw new BlackDuckIntegrationException(String.format("Could not construct the URL from %s and %s", baseUrl, spec), e);
+        }
+        return url.toString();
+    }
+}


### PR DESCRIPTION
Completes INTCMN-416.
Allows the user to specify how many pages they would like to retrieve. I considered total count, but that got complicated quickly. If the user wants a more precise number, they can use the BlackDuckResponsesTransformer directly and pass in a custom PagedRequest with their own offsets and limits. BlackDuckResponsesTransformer is now exposed on BlackDuckService for convenience.

Also added direct tests for BlackDuckResponsesTransformer.