### PR TITLE
Add individual file matches to scan command

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -55,6 +55,7 @@ public class ScanBatch extends Stringable implements Buildable {
     private final String additionalScanArguments;
     private final SnippetMatching snippetMatchingMode;
     private final boolean uploadSource;
+    private final String individualFileMatching;
     private final URL blackDuckUrl;
     private final String blackDuckUsername;
     private final String blackDuckPassword;
@@ -63,12 +64,11 @@ public class ScanBatch extends Stringable implements Buildable {
     private final boolean alwaysTrustServerCertificate;
     private final String projectName;
     private final String projectVersionName;
-    private final String individualFileMatching;
     private final List<ScanTarget> scanTargets;
 
     public ScanBatch(final File signatureScannerInstallDirectory, final File outputDirectory, final boolean cleanupOutput, final int scanMemoryInMegabytes, final boolean dryRun, final boolean debug, final boolean verbose,
-            final String scanCliOpts, final String additionalScanArguments, final SnippetMatching snippetMatchingMode, final boolean uploadSource, final URL blackDuckUrl, final String blackDuckUsername, final String blackDuckPassword, final String blackDuckApiToken,
-            final ProxyInfo proxyInfo, final boolean alwaysTrustServerCertificate, final String projectName, final String projectVersionName, final String individualFileMatching, final List<ScanTarget> scanTargets) {
+            final String scanCliOpts, final String additionalScanArguments, final SnippetMatching snippetMatchingMode, final boolean uploadSource, final String individualFileMatching, final URL blackDuckUrl, final String blackDuckUsername, final String blackDuckPassword, final String blackDuckApiToken,
+            final ProxyInfo proxyInfo, final boolean alwaysTrustServerCertificate, final String projectName, final String projectVersionName, final List<ScanTarget> scanTargets) {
         this.signatureScannerInstallDirectory = signatureScannerInstallDirectory;
         this.outputDirectory = outputDirectory;
         this.cleanupOutput = cleanupOutput;
@@ -80,6 +80,7 @@ public class ScanBatch extends Stringable implements Buildable {
         this.additionalScanArguments = additionalScanArguments;
         this.snippetMatchingMode = snippetMatchingMode;
         this.uploadSource = uploadSource;
+        this.individualFileMatching = individualFileMatching;
         this.blackDuckUrl = blackDuckUrl;
         this.blackDuckUsername = blackDuckUsername;
         this.blackDuckPassword = blackDuckPassword;
@@ -88,7 +89,6 @@ public class ScanBatch extends Stringable implements Buildable {
         this.alwaysTrustServerCertificate = alwaysTrustServerCertificate;
         this.projectName = projectName;
         this.projectVersionName = projectVersionName;
-        this.individualFileMatching = individualFileMatching;
         this.scanTargets = scanTargets;
     }
 
@@ -138,7 +138,7 @@ public class ScanBatch extends Stringable implements Buildable {
             }
             final ScanCommand scanCommand = new ScanCommand(installDirectoryForCommand, commandOutputDirectory, commandDryRun, proxyInfo, scanCliOptsToUse, scanMemoryInMegabytes, commandScheme, commandHost,
                     blackDuckApiToken, blackDuckUsername, blackDuckPassword, commandPort, alwaysTrustServerCertificate, scanTarget.getCodeLocationName(), snippetMatching, snippetMatchingOnly, fullSnippetScan,
-                    uploadSource, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, individualFileMatching);
+                    uploadSource, individualFileMatching, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName);
             scanCommands.add(scanCommand);
         }
 
@@ -189,6 +189,10 @@ public class ScanBatch extends Stringable implements Buildable {
         return uploadSource;
     }
 
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
+    }
+
     public URL getBlackDuckUrl() {
         return blackDuckUrl;
     }
@@ -219,10 +223,6 @@ public class ScanBatch extends Stringable implements Buildable {
 
     public String getProjectVersionName() {
         return projectVersionName;
-    }
-
-    public String getIndividualFileMatching() {
-        return individualFileMatching;
     }
 
     public List<ScanTarget> getScanTargets() {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -35,7 +35,6 @@ import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationException;
 import com.synopsys.integration.builder.Buildable;
-import com.synopsys.integration.rest.credentials.CredentialsBuilder;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.util.IntEnvironmentVariables;
 import com.synopsys.integration.util.Stringable;
@@ -64,11 +63,12 @@ public class ScanBatch extends Stringable implements Buildable {
     private final boolean alwaysTrustServerCertificate;
     private final String projectName;
     private final String projectVersionName;
+    private final String individualFileMatching;
     private final List<ScanTarget> scanTargets;
 
     public ScanBatch(final File signatureScannerInstallDirectory, final File outputDirectory, final boolean cleanupOutput, final int scanMemoryInMegabytes, final boolean dryRun, final boolean debug, final boolean verbose,
             final String scanCliOpts, final String additionalScanArguments, final SnippetMatching snippetMatchingMode, final boolean uploadSource, final URL blackDuckUrl, final String blackDuckUsername, final String blackDuckPassword, final String blackDuckApiToken,
-            final ProxyInfo proxyInfo, final boolean alwaysTrustServerCertificate, final String projectName, final String projectVersionName, final List<ScanTarget> scanTargets) {
+            final ProxyInfo proxyInfo, final boolean alwaysTrustServerCertificate, final String projectName, final String projectVersionName, final String individualFileMatching, final List<ScanTarget> scanTargets) {
         this.signatureScannerInstallDirectory = signatureScannerInstallDirectory;
         this.outputDirectory = outputDirectory;
         this.cleanupOutput = cleanupOutput;
@@ -88,6 +88,7 @@ public class ScanBatch extends Stringable implements Buildable {
         this.alwaysTrustServerCertificate = alwaysTrustServerCertificate;
         this.projectName = projectName;
         this.projectVersionName = projectVersionName;
+        this.individualFileMatching = individualFileMatching;
         this.scanTargets = scanTargets;
     }
 
@@ -137,7 +138,7 @@ public class ScanBatch extends Stringable implements Buildable {
             }
             final ScanCommand scanCommand = new ScanCommand(installDirectoryForCommand, commandOutputDirectory, commandDryRun, proxyInfo, scanCliOptsToUse, scanMemoryInMegabytes, commandScheme, commandHost,
                     blackDuckApiToken, blackDuckUsername, blackDuckPassword, commandPort, alwaysTrustServerCertificate, scanTarget.getCodeLocationName(), snippetMatching, snippetMatchingOnly, fullSnippetScan,
-                    uploadSource, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName);
+                    uploadSource, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, individualFileMatching);
             scanCommands.add(scanCommand);
         }
 
@@ -218,6 +219,10 @@ public class ScanBatch extends Stringable implements Buildable {
 
     public String getProjectVersionName() {
         return projectVersionName;
+    }
+
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
     }
 
     public List<ScanTarget> getScanTargets() {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -55,6 +55,8 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private SnippetMatching snippetMatching;
     private boolean uploadSource;
 
+    private String individualFileMatching;
+
     private URL blackDuckUrl;
     private String blackDuckUsername;
     private String blackDuckPassword;
@@ -65,14 +67,12 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private String projectName;
     private String projectVersionName;
 
-    private String individualFileMatching;
-
     private List<ScanTarget> scanTargets = new ArrayList<>();
 
     @Override
     protected ScanBatch buildWithoutValidation() {
-        return new ScanBatch(installDirectory, outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments, snippetMatching, uploadSource, blackDuckUrl, blackDuckUsername,
-                blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate, projectName, projectVersionName, individualFileMatching, scanTargets);
+        return new ScanBatch(installDirectory, outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments, snippetMatching, uploadSource, individualFileMatching, blackDuckUrl, blackDuckUsername,
+                blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate, projectName, projectVersionName, scanTargets);
     }
 
     @Override
@@ -273,6 +273,14 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
         return this;
     }
 
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
+    }
+
+    public void individualFileMatching(final String individualFileMatching) {
+        this.individualFileMatching = individualFileMatching;
+    }
+
     public URL getBlackDuckUrl() {
         return blackDuckUrl;
     }
@@ -333,14 +341,6 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
 
     public String getProjectVersionName() {
         return projectVersionName;
-    }
-
-    public String getIndividualFileMatching() {
-        return individualFileMatching;
-    }
-
-    public void individualFileMatching(final String individualFileMatching) {
-        this.individualFileMatching = individualFileMatching;
     }
 
     public List<ScanTarget> getScanTargets() {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -65,12 +65,14 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private String projectName;
     private String projectVersionName;
 
+    private String individualFileMatching;
+
     private List<ScanTarget> scanTargets = new ArrayList<>();
 
     @Override
     protected ScanBatch buildWithoutValidation() {
         return new ScanBatch(installDirectory, outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments, snippetMatching, uploadSource, blackDuckUrl, blackDuckUsername,
-                blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate, projectName, projectVersionName, scanTargets);
+                blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate, projectName, projectVersionName, individualFileMatching, scanTargets);
     }
 
     @Override
@@ -331,6 +333,14 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
 
     public String getProjectVersionName() {
         return projectVersionName;
+    }
+
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
+    }
+
+    public void individualFileMatching(final String individualFileMatching) {
+        this.individualFileMatching = individualFileMatching;
     }
 
     public List<ScanTarget> getScanTargets() {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -51,6 +51,7 @@ public class ScanCommand {
     private final boolean snippetMatchingOnly;
     private final boolean fullSnippetScan;
     private final boolean uploadSource;
+    private final String individualFileMatching;
     private final Set<String> excludePatterns;
     private final String additionalArguments;
     private final String targetPath;
@@ -58,11 +59,10 @@ public class ScanCommand {
     private final boolean debug;
     private final String projectName;
     private final String versionName;
-    private final String individualFileMatching;
 
     public ScanCommand(final File installDirectory, final File outputDirectory, final boolean dryRun, final ProxyInfo proxyInfo, final String scanCliOpts, final int scanMemoryInMegabytes, final String scheme,
             final String host, final String apiToken, final String username, final String password, final int port, final boolean runInsecure, final String name, final boolean snippetMatching, final boolean snippetMatchingOnly,
-            final boolean fullSnippetScan, final boolean uploadSource, final Set<String> excludePatterns, final String additionalArguments, final String targetPath, final boolean verbose, final boolean debug, final String projectName, final String versionName, final String individualFileMatching) {
+            final boolean fullSnippetScan, final boolean uploadSource, final String individualFileMatching, final Set<String> excludePatterns, final String additionalArguments, final String targetPath, final boolean verbose, final boolean debug, final String projectName, final String versionName) {
         this.installDirectory = installDirectory;
         this.outputDirectory = outputDirectory;
         this.dryRun = dryRun;
@@ -81,6 +81,7 @@ public class ScanCommand {
         this.snippetMatchingOnly = snippetMatchingOnly;
         this.fullSnippetScan = fullSnippetScan;
         this.uploadSource = uploadSource;
+        this.individualFileMatching = individualFileMatching;
         this.excludePatterns = excludePatterns;
         this.additionalArguments = additionalArguments;
         this.targetPath = targetPath;
@@ -88,7 +89,6 @@ public class ScanCommand {
         this.debug = debug;
         this.projectName = projectName;
         this.versionName = versionName;
-        this.individualFileMatching = individualFileMatching;
     }
 
     public List<String> createCommandForProcessBuilder(final IntLogger logger, final ScanPaths scannerPaths, final String specificRunOutputDirectoryPath) throws IllegalArgumentException {
@@ -309,6 +309,10 @@ public class ScanCommand {
         return uploadSource;
     }
 
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
+    }
+
     public Set<String> getExcludePatterns() {
         return excludePatterns;
     }
@@ -337,7 +341,4 @@ public class ScanCommand {
         return versionName;
     }
 
-    public String getIndividualFileMatching() {
-        return individualFileMatching;
-    }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.log.IntLogger;
-import com.synopsys.integration.log.SilentIntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
 public class ScanCommand {
@@ -59,10 +58,11 @@ public class ScanCommand {
     private final boolean debug;
     private final String projectName;
     private final String versionName;
+    private final String individualFileMatching;
 
     public ScanCommand(final File installDirectory, final File outputDirectory, final boolean dryRun, final ProxyInfo proxyInfo, final String scanCliOpts, final int scanMemoryInMegabytes, final String scheme,
             final String host, final String apiToken, final String username, final String password, final int port, final boolean runInsecure, final String name, final boolean snippetMatching, final boolean snippetMatchingOnly,
-            final boolean fullSnippetScan, final boolean uploadSource, final Set<String> excludePatterns, final String additionalArguments, final String targetPath, final boolean verbose, final boolean debug, final String projectName, final String versionName) {
+            final boolean fullSnippetScan, final boolean uploadSource, final Set<String> excludePatterns, final String additionalArguments, final String targetPath, final boolean verbose, final boolean debug, final String projectName, final String versionName, final String individualFileMatching) {
         this.installDirectory = installDirectory;
         this.outputDirectory = outputDirectory;
         this.dryRun = dryRun;
@@ -88,6 +88,7 @@ public class ScanCommand {
         this.debug = debug;
         this.projectName = projectName;
         this.versionName = versionName;
+        this.individualFileMatching = individualFileMatching;
     }
 
     public List<String> createCommandForProcessBuilder(final IntLogger logger, final ScanPaths scannerPaths, final String specificRunOutputDirectoryPath) throws IllegalArgumentException {
@@ -219,6 +220,11 @@ public class ScanCommand {
                 }
             }
         }
+
+        if (StringUtils.isNotBlank(individualFileMatching)) {
+            cmd.add("--individualFileMatching=" + individualFileMatching);
+        }
+
         final String additionalScanArguments = additionalArguments;
         if (StringUtils.isNotBlank(additionalScanArguments)) {
             for (final String additionalArgument : additionalScanArguments.split(" ")) {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -337,4 +337,7 @@ public class ScanCommand {
         return versionName;
     }
 
+    public String getIndividualFileMatching() {
+        return individualFileMatching;
+    }
 }


### PR DESCRIPTION
Adding field individualFileMatching to ScanCommand to reflect new parameter in BD CLI

https://jira-sig.internal.synopsys.com/browse/IDETECT-1860