### PR TITLE
Utilize library class to parse command string into list of arguments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     api 'com.blackducksoftware.bdio:bdio2:3.0.0-beta.47'
 
     implementation 'org.apache.commons:commons-collections4:4.4'
-    compile group: 'org.apache.ant', name: 'ant', version: '1.8.2'
+    compile group: 'org.apache.ant', name: 'ant', version: '1.9.0'
 
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.mockito:mockito-core:2.18.3'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     api 'com.blackducksoftware.bdio:bdio2:3.0.0-beta.47'
 
     implementation 'org.apache.commons:commons-collections4:4.4'
+    compile group: 'org.apache.ant', name: 'ant', version: '1.8.2'
 
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.mockito:mockito-core:2.18.3'

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.tools.ant.types.Commandline;
 
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
+
 
 public class ScanCommand {
     private final String scheme;
@@ -147,9 +149,10 @@ public class ScanCommand {
     //--value="this thing that is important with spaces"
     private void populateAdditionalScanArguments(List<String> cmd) {
         if (StringUtils.isNotBlank(additionalScanArguments)) {
-            for (String additionalArgument : additionalScanArguments.split(" ")) {
-                if (StringUtils.isNotBlank(additionalArgument)) {
-                    cmd.add(additionalArgument);
+            String[] arguments = Commandline.translateCommandline(additionalScanArguments);
+            for (String argument : arguments) {
+                if (StringUtils.isNotBlank(argument)) {
+                    cmd.add(argument);
                 }
             }
         }

--- a/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.blackduck.codelocation.signaturescanner.command
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -170,6 +171,14 @@ public class ScanCommandTest {
         scanBatchBuilder.individualFileMatching(IndividualFileMatching.BINARY);
         List<String> commandList = createCommandList();
         assertIndividualFileMatching(commandList, IndividualFileMatching.BINARY);
+    }
+
+    @Test
+    public void testAdditionalArgumentsWithSpaces() throws BlackDuckIntegrationException {
+        scanBatchBuilder.additionalScanArguments("--upload-source --exclude \"/Users/joe/test folder/\" --name \"my--test\"");
+        List<String> commandList = createCommandList();
+        assertTrue(commandList.contains("/Users/joe/test folder/"));
+        assertTrue(commandList.contains("my--test"));
     }
 
     private void populateBuilder(ScanBatchBuilder scanBatchBuilder) {


### PR DESCRIPTION
This is a potential solution for issues faced by the current implementation for parsing a string of scan cli arguments.
Outsourcing parsing to org.apache.tools.ant.types.Commandline.
Added a test to ScanCommandTest to assure edge cases that we were previously vulnerable to are now handled (input on what other edge cases may be missed by the test/what other behavior we'd wish to verify would be appreciated).
