### PR TITLE
Jm project service predicate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ project.ext.moduleName = 'com.synopsys.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '51.0.1-SNAPSHOT'
+version = '51.1.0-SNAPSHOT'
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponsesTransformer.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponsesTransformer.java
@@ -52,6 +52,10 @@ public class BlackDuckResponsesTransformer {
         return getInternalMatchingResponse(pagedRequest, clazz, totalLimit, predicate);
     }
 
+    public <T extends BlackDuckResponse> BlackDuckPageResponse<T> getAllMatchingResponses(PagedRequest pagedRequest, Class<T> clazz, Predicate<T> predicate) throws IntegrationException {
+        return getInternalMatchingResponse(pagedRequest, clazz, Integer.MAX_VALUE, predicate);
+    }
+
     public <T extends BlackDuckResponse> BlackDuckPageResponse<T> getAllResponses(PagedRequest pagedRequest, Class<T> clazz) throws IntegrationException {
         return getInternalMatchingResponse(pagedRequest, clazz, Integer.MAX_VALUE, alwaysTrue());
     }

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -103,6 +103,14 @@ public class BlackDuckApiClient {
         return getBlackDuckPathResponses(blackDuckPathMultipleResponses, requestBuilder, (pagedRequest, responseClass) -> blackDuckResponsesTransformer.getSomeMatchingResponses(pagedRequest, responseClass, predicate, totalLimit));
     }
 
+    public <T extends BlackDuckResponse> List<T> getAllMatchingResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses, Predicate<T> predicate) throws IntegrationException {
+        return getAllMatchingResponses(blackDuckPathMultipleResponses, blackDuckRequestFactory.createCommonGetRequestBuilder(), predicate);
+    }
+
+    public <T extends BlackDuckResponse> List<T> getAllMatchingResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses, BlackDuckRequestBuilder requestBuilder, Predicate<T> predicate) throws IntegrationException {
+        return getBlackDuckPathResponses(blackDuckPathMultipleResponses, requestBuilder, (pagedRequest, responseClass) -> blackDuckResponsesTransformer.getAllMatchingResponses(pagedRequest, responseClass, predicate));
+    }
+
     public <T extends BlackDuckResponse> List<T> getAllResponses(BlackDuckPathMultipleResponses<T> blackDuckPathMultipleResponses) throws IntegrationException {
         return getAllResponses(blackDuckPathMultipleResponses, blackDuckRequestFactory.createCommonGetRequestBuilder());
     }

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectService.java
@@ -25,6 +25,7 @@ package com.synopsys.integration.blackduck.service.dataservice;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
@@ -52,6 +53,10 @@ public class ProjectService extends DataService {
 
     public List<ProjectView> getAllProjects() throws IntegrationException {
         return blackDuckApiClient.getAllResponses(ApiDiscovery.PROJECTS_LINK_RESPONSE);
+    }
+
+    public List<ProjectView> getAllProjects(Predicate<ProjectView> includeProjectViewPredicate) throws IntegrationException {
+        return blackDuckApiClient.getAllMatchingResponses(ApiDiscovery.PROJECTS_LINK_RESPONSE, includeProjectViewPredicate);
     }
 
     public ProjectVersionWrapper createProject(ProjectRequest projectRequest) throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
@@ -64,6 +64,20 @@ public class ProjectServiceTestIT {
     }
 
     @Test
+    void testGetAllMatchingProjects() throws IntegrationException {
+        long timestamp = new Date().getTime();
+        String testProjectName = "hub-common-it-ProjectServiceTest-" + timestamp;
+        ProjectRequest projectRequest = new ProjectRequest();
+        projectRequest.setName(testProjectName);
+        ProjectVersionWrapper projectVersionWrapper = ProjectServiceTestIT.projectService.createProject(projectRequest);
+        ProjectServiceTestIT.project = projectVersionWrapper.getProjectView();
+
+        List<ProjectView> allMatchingProjects = ProjectServiceTestIT.projectService.getAllProjects((projectView -> projectView.getName().equals(testProjectName)));
+
+        assertEquals(1, allMatchingProjects.size());
+    }
+
+    @Test
     public void testCreateDeleteWithNickname() throws IllegalArgumentException, IntegrationException {
         Long timestamp = (new Date()).getTime();
         String testProjectName = "hub-common-it-ProjectServiceTest-" + timestamp;


### PR DESCRIPTION
Adds the ability for `ProjectService` to accept a `Predicate` for filtering results when getting all projects from Black Duck.