### PR TITLE
Provide API for getting suggested license names for a given query token.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ project.ext.moduleName = 'com.synopsys.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '59.0.7-SNAPSHOT'
+version = '60.0.0-SNAPSHOT'
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/LicenseService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/LicenseService.java
@@ -79,8 +79,8 @@ public class LicenseService extends DataService {
 
     public List<LicenseView> searchLicensesByName(String licenseName) throws IntegrationException {
         BlackDuckQuery nameQuery = new BlackDuckQuery("name:" + licenseName);
-            BlackDuckRequest<LicenseView, UrlMultipleResponses<LicenseView>> requestMultiple = new BlackDuckRequest<>(new BlackDuckRequestBuilder().commonGet().addBlackDuckQuery(nameQuery), apiDiscovery.metaLicensesLink());
-            return blackDuckApiClient.getAllResponses(requestMultiple);
+        BlackDuckRequest<LicenseView, UrlMultipleResponses<LicenseView>> requestMultiple = new BlackDuckRequest<>(new BlackDuckRequestBuilder().commonGet().addBlackDuckQuery(nameQuery), apiDiscovery.metaLicensesLink());
+        return blackDuckApiClient.getAllResponses(requestMultiple);
     }
 
     public Optional<HttpUrl> getLicenseUrlByLicenseName(String licenseName) {

--- a/src/test/java/com/synopsys/integration/blackduck/service/dataservice/LicenseDataServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/dataservice/LicenseDataServiceTestIT.java
@@ -59,7 +59,7 @@ public class LicenseDataServiceTestIT {
         BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory();
         LicenseService licenseService = blackDuckServicesFactory.createLicenseService();
         String licenseName = ".NETZ GPL 2.0 With Exception License";
-        licenseService.getLicenseUrlByLicenseName(licenseName).string();
+        licenseService.getLicenseUrlByLicenseName(licenseName).get().string();
     }
 
     @Test
@@ -67,7 +67,7 @@ public class LicenseDataServiceTestIT {
         BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory();
         LicenseService licenseService = blackDuckServicesFactory.createLicenseService();
         String licenseName = "fakeLicenseName";
-        Assertions.assertThrows(IntegrationException.class, () -> licenseService.getLicenseUrlByLicenseName(licenseName).string());
+        Assertions.assertThrows(IntegrationException.class, () -> licenseService.getLicenseUrlByLicenseName(licenseName).get().string());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
@@ -83,7 +83,7 @@ public class ProjectServiceTestIT {
 
         ComplexLicenseRequest complexLicenseRequest = new ComplexLicenseRequest();
         String licenseName = ".NETZ GPL 2.0 With Exception License";
-        complexLicenseRequest.setLicense(licenseService.getLicenseUrlByLicenseName(licenseName).string());
+        complexLicenseRequest.setLicense(licenseService.getLicenseUrlByLicenseName(licenseName).get().string());
         projectVersionRequest.setLicense(complexLicenseRequest);
 
         projectRequest.setVersionRequest(projectVersionRequest);


### PR DESCRIPTION
Also made getLicenseUrlByLicenseName return an Optional instead of throwing an exception on a miss.