### PR TITLE
Sb retry bdio upload

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -31,18 +31,18 @@ public class Bdio2FileUploadService extends DataService {
     private static final int BD_WAIT_AND_RETRY_INTERVAL = 30;
 
     private final Bdio2ContentExtractor bdio2Extractor;
-    private final Bdio2StreamUploader bdio2Uploader;
+    private final Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader;
 
     public Bdio2FileUploadService(
         BlackDuckApiClient blackDuckApiClient,
         ApiDiscovery apiDiscovery,
         IntLogger logger,
         Bdio2ContentExtractor bdio2Extractor,
-        Bdio2StreamUploader bdio2Uploader
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader
     ) {
         super(blackDuckApiClient, apiDiscovery, logger);
         this.bdio2Extractor = bdio2Extractor;
-        this.bdio2Uploader = bdio2Uploader;
+        this.bdio2RetryAwareStreamUploader = bdio2RetryAwareStreamUploader;
     }
 
     public Bdio2UploadResult uploadFile(UploadTarget uploadTarget, long timeout) throws IntegrationException, InterruptedException {
@@ -81,7 +81,7 @@ public class Bdio2FileUploadService extends DataService {
         }
 
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, timeout, System.currentTimeMillis(), BD_WAIT_AND_RETRY_INTERVAL);
-        Bdio2UploadJob bdio2UploadJob = new Bdio2UploadJob(bdio2Uploader, header, remainingFiles, editor, count, shouldUploadEntries, shouldFinishUpload);
+        Bdio2UploadJob bdio2UploadJob = new Bdio2UploadJob(bdio2RetryAwareStreamUploader, header, remainingFiles, editor, count, shouldUploadEntries, shouldFinishUpload);
         ResilientJobExecutor jobExecutor = new ResilientJobExecutor(jobConfig);
 
         return jobExecutor.executeJob(bdio2UploadJob);

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -1,0 +1,90 @@
+/*
+ * blackduck-common
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.bdio2;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
+import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
+import com.synopsys.integration.rest.response.Response;
+
+public class Bdio2RetryAwareStreamUploader {
+    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 500);
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Bdio2StreamUploader bdio2StreamUploader;
+
+    public Bdio2RetryAwareStreamUploader(final Bdio2StreamUploader bdio2StreamUploader) {
+        this.bdio2StreamUploader = bdio2StreamUploader;
+    }
+
+    public Response executeUploadStart(BdioFileContent header, BlackDuckRequestBuilderEditor editor)
+        throws RetriableBdioUploadException, IntegrationException {
+        logger.trace("Executing BDIO upload start operation");
+        try {
+            return bdio2StreamUploader.start(header, editor);
+        } catch (IntegrationRestException e) {
+            return translateRetryableExceptions(e);
+        }
+    }
+
+    public Response executeUploadAppend(HttpUrl uploadUrl, int count, BdioFileContent content, BlackDuckRequestBuilderEditor editor)
+        throws RetriableBdioUploadException, IntegrationException {
+        logger.trace("Executing BDIO upload append operation");
+        Response response = null;
+        try {
+            response = bdio2StreamUploader.append(uploadUrl, count, content, editor);
+        } catch (IntegrationRestException e) {
+            translateRetryableExceptions(e);
+        }
+        return response;
+    }
+
+    public Response executeUploadFinish(HttpUrl uploadUrl, int count, BlackDuckRequestBuilderEditor editor)
+        throws RetriableBdioUploadException, IntegrationException {
+        logger.trace("Executing BDIO upload finish operation");
+        Response response = null;
+        try {
+            response = bdio2StreamUploader.finish(uploadUrl, count, editor);
+        } catch (IntegrationRestException e) {
+            translateRetryableExceptions(e);
+        }
+        return response;
+    }
+
+
+    // If response is unsuccessful, throw a recoverable RetriableBdioUploadException unless we get a failure status code in which case we throw an unrecoverable exception
+    public void throwIfRetryableExitCode(Response response) throws IntegrationException, RetriableBdioUploadException {
+        if (!response.isStatusCodeSuccess()) {
+            if (isRetryableExitCode(response.getStatusCode())) {
+                throw new RetriableBdioUploadException();
+            }
+            throw new IntegrationException(String.format("Bdio upload failed with non-retryable exit code: %d", response.getStatusCode()));
+        }
+    }
+
+    private Response translateRetryableExceptions(final IntegrationRestException e) throws RetriableBdioUploadException, IntegrationRestException {
+        if (isRetryableExitCode(e.getHttpStatusCode())) {
+            throw new RetriableBdioUploadException();
+        }
+        throw e;
+    }
+
+    private boolean isRetryableExitCode(int exitCode) {
+        if (NON_RETRYABLE_EXIT_CODES.contains(exitCode)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -63,9 +63,7 @@ public class Bdio2RetryAwareStreamUploader {
         return response;
     }
 
-
-    // If response is unsuccessful, throw a recoverable RetriableBdioUploadException unless we get a failure status code in which case we throw an unrecoverable exception
-    public void throwIfRetryableExitCode(Response response) throws IntegrationException, RetriableBdioUploadException {
+    public void onErrorThrowRetryableOrFailure(Response response) throws IntegrationException, RetriableBdioUploadException {
         if (!response.isStatusCodeSuccess()) {
             if (isRetryableExitCode(response.getStatusCode())) {
                 throw new RetriableBdioUploadException();

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -29,7 +29,7 @@ public class Bdio2RetryAwareStreamUploader {
         this.bdio2StreamUploader = bdio2StreamUploader;
     }
 
-    public Response executeUploadStart(BdioFileContent header, BlackDuckRequestBuilderEditor editor)
+    public Response start(BdioFileContent header, BlackDuckRequestBuilderEditor editor)
         throws RetriableBdioUploadException, IntegrationException {
         logger.trace("Executing BDIO upload start operation");
         try {
@@ -39,7 +39,7 @@ public class Bdio2RetryAwareStreamUploader {
         }
     }
 
-    public Response executeUploadAppend(HttpUrl uploadUrl, int count, BdioFileContent content, BlackDuckRequestBuilderEditor editor)
+    public Response append(HttpUrl uploadUrl, int count, BdioFileContent content, BlackDuckRequestBuilderEditor editor)
         throws RetriableBdioUploadException, IntegrationException {
         logger.trace("Executing BDIO upload append operation");
         Response response = null;
@@ -51,7 +51,7 @@ public class Bdio2RetryAwareStreamUploader {
         return response;
     }
 
-    public Response executeUploadFinish(HttpUrl uploadUrl, int count, BlackDuckRequestBuilderEditor editor)
+    public Response finish(HttpUrl uploadUrl, int count, BlackDuckRequestBuilderEditor editor)
         throws RetriableBdioUploadException, IntegrationException {
         logger.trace("Executing BDIO upload finish operation");
         Response response = null;

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -25,7 +25,7 @@ public class Bdio2RetryAwareStreamUploader {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final Bdio2StreamUploader bdio2StreamUploader;
 
-    public Bdio2RetryAwareStreamUploader(final Bdio2StreamUploader bdio2StreamUploader) {
+    public Bdio2RetryAwareStreamUploader(Bdio2StreamUploader bdio2StreamUploader) {
         this.bdio2StreamUploader = bdio2StreamUploader;
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
@@ -57,7 +57,7 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
     @Override
     public void attemptJob() throws IntegrationException {
         try {
-            Response headerResponse = bdio2RetryAwareStreamUploader.executeUploadStart(header, editor);
+            Response headerResponse = bdio2RetryAwareStreamUploader.start(header, editor);
             bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(headerResponse);
             complete = true;
             uploadUrl = new HttpUrl(headerResponse.getHeaderValue("location"));
@@ -65,12 +65,12 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
             if (shouldUploadEntries) {
                 logger.debug(String.format("Starting upload to %s", uploadUrl.string()));
                 for (BdioFileContent content : bdioEntries) {
-                    Response chunkResponse = bdio2RetryAwareStreamUploader.executeUploadAppend(uploadUrl, count, content, editor);
+                    Response chunkResponse = bdio2RetryAwareStreamUploader.append(uploadUrl, count, content, editor);
                     bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(chunkResponse);
                 }
             }
             if (shouldFinishUpload) {
-                Response finishResponse = bdio2RetryAwareStreamUploader.executeUploadFinish(uploadUrl, count, editor);
+                Response finishResponse = bdio2RetryAwareStreamUploader.finish(uploadUrl, count, editor);
                 bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(finishResponse);
             }
         } catch (RetriableBdioUploadException e) {

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
@@ -58,8 +58,8 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
     public void attemptJob() throws IntegrationException {
         try {
             Response headerResponse = bdio2RetryAwareStreamUploader.executeUploadStart(header, editor);
-            complete = true;
             bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(headerResponse);
+            complete = true;
             uploadUrl = new HttpUrl(headerResponse.getHeaderValue("location"));
             scanId = parseScanIdFromUploadUrl(uploadUrl.string());
             if (shouldUploadEntries) {
@@ -70,7 +70,8 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
                 }
             }
             if (shouldFinishUpload) {
-                bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(bdio2RetryAwareStreamUploader.executeUploadFinish(uploadUrl, count, editor));
+                Response finishResponse = bdio2RetryAwareStreamUploader.executeUploadFinish(uploadUrl, count, editor);
+                bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(finishResponse);
             }
         } catch (RetriableBdioUploadException e) {
             complete = false;

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckServicesFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckServicesFactory.java
@@ -18,6 +18,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.bdio2.Bdio2FileUploadService;
+import com.synopsys.integration.blackduck.bdio2.Bdio2RetryAwareStreamUploader;
 import com.synopsys.integration.blackduck.bdio2.Bdio2StreamUploader;
 import com.synopsys.integration.blackduck.bdio2.util.Bdio2ContentExtractor;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationService;
@@ -134,7 +135,8 @@ public class BlackDuckServicesFactory {
         Bdio2StreamUploader bdio2Uploader = new Bdio2StreamUploader(blackDuckApiClient, apiDiscovery, logger, ApiDiscovery.INTELLIGENT_PERSISTENCE_SCANS_PATH,
             IntelligentPersistenceService.CONTENT_TYPE
         );
-        return new Bdio2FileUploadService(blackDuckApiClient, apiDiscovery, logger, new Bdio2ContentExtractor(), bdio2Uploader);
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = new Bdio2RetryAwareStreamUploader(bdio2Uploader);
+        return new Bdio2FileUploadService(blackDuckApiClient, apiDiscovery, logger, new Bdio2ContentExtractor(), bdio2RetryAwareStreamUploader);
     }
 
     public SignatureScannerService createSignatureScannerService(File signatureScannerInstallDirectory) {

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -17,9 +17,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     void testStartRetriable() throws IntegrationException {
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
-
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnStart(editor, bdioFileContent);
-
         try {
             bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
             Assertions.fail("Expected RetriableBdioUploadException");
@@ -33,7 +31,6 @@ class Bdio2RetryAwareStreamUploaderTest {
         HttpUrl httpUrl = Mockito.mock(HttpUrl.class);
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
-
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnAppend(httpUrl, bdioFileContent, editor);
         try {
             bdio2RetryAwareStreamUploader.append(httpUrl, 1, bdioFileContent, editor);
@@ -48,7 +45,6 @@ class Bdio2RetryAwareStreamUploaderTest {
         HttpUrl httpUrl = Mockito.mock(HttpUrl.class);
         //BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
-
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnFinish(httpUrl, editor);
         try {
             bdio2RetryAwareStreamUploader.finish(httpUrl, 1, editor);
@@ -62,7 +58,6 @@ class Bdio2RetryAwareStreamUploaderTest {
     void testStartNonRetriable() throws IntegrationException, RetriableBdioUploadException {
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
-
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrow404OnStart(bdioFileContent, editor);
         try {
             bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
@@ -73,7 +68,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @NotNull
-    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrow404OnStart(final BdioFileContent bdioFileContent, final BlackDuckRequestBuilderEditor editor)
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrow404OnStart(BdioFileContent bdioFileContent, BlackDuckRequestBuilderEditor editor)
         throws IntegrationException {
         Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
@@ -84,7 +79,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @NotNull
-    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnStart(final BlackDuckRequestBuilderEditor editor, final BdioFileContent bdioFileContent)
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnStart(BlackDuckRequestBuilderEditor editor, BdioFileContent bdioFileContent)
         throws IntegrationException {
         Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
         IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
@@ -94,7 +89,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @NotNull
-    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnAppend(final HttpUrl httpUrl, final BdioFileContent bdioFileContent, final BlackDuckRequestBuilderEditor editor)
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnAppend(HttpUrl httpUrl, BdioFileContent bdioFileContent, BlackDuckRequestBuilderEditor editor)
         throws IntegrationException {
         Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
         IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
@@ -104,7 +99,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @NotNull
-    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnFinish(final HttpUrl httpUrl, final BlackDuckRequestBuilderEditor editor)
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnFinish(HttpUrl httpUrl, BlackDuckRequestBuilderEditor editor)
         throws IntegrationException {
         Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
         IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -1,30 +1,115 @@
 package com.synopsys.integration.blackduck.bdio2;
 
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
 import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
-import com.synopsys.integration.rest.response.Response;
 
-public class Bdio2RetryAwareStreamUploaderTest {
+class Bdio2RetryAwareStreamUploaderTest {
 
     @Test
-    void test() throws IntegrationException, RetriableBdioUploadException {
-        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
-        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
+    void testStartRetriable() throws IntegrationException {
+        BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
+        BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
 
-        BdioFileContent header = Mockito.mock(BdioFileContent.class);
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnStart(editor, bdioFileContent);
+
+        try {
+            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
+            Assertions.fail("Expected RetriableBdioUploadException");
+        } catch (RetriableBdioUploadException e) {
+            // expected
+        }
+    }
+
+    @Test
+    void testAppendRetriable() throws IntegrationException {
+        HttpUrl httpUrl = Mockito.mock(HttpUrl.class);
+        BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
 
-        // bdio2StreamUploader.start(header, editor);
-        Response response512 = Mockito.mock(Response.class);
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnAppend(httpUrl, bdioFileContent, editor);
+        try {
+            bdio2RetryAwareStreamUploader.append(httpUrl, 1, bdioFileContent, editor);
+            Assertions.fail("Expected RetriableBdioUploadException");
+        } catch (RetriableBdioUploadException e) {
+            // expected
+        }
+    }
+
+    @Test
+    void testFinishRetriable() throws IntegrationException {
+        HttpUrl httpUrl = Mockito.mock(HttpUrl.class);
+        //BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
+        BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
+
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnFinish(httpUrl, editor);
+        try {
+            bdio2RetryAwareStreamUploader.finish(httpUrl, 1, editor);
+            Assertions.fail("Expected RetriableBdioUploadException");
+        } catch (RetriableBdioUploadException e) {
+            // expected
+        }
+    }
+
+    @Test
+    void testStartNonRetriable() throws IntegrationException, RetriableBdioUploadException {
+        BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
+        BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
+
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrow404OnStart(bdioFileContent, editor);
+        try {
+            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
+            Assertions.fail("Expected RetriableBdioUploadException");
+        } catch (IntegrationException e) {
+            // expected
+        }
+    }
+
+    @NotNull
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrow404OnStart(final BdioFileContent bdioFileContent, final BlackDuckRequestBuilderEditor editor)
+        throws IntegrationException {
+        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
+        IntegrationRestException exception404 = Mockito.mock(IntegrationRestException.class);
+        Mockito.when(bdio2StreamUploader.start(bdioFileContent, editor)).thenThrow(exception404);
+        Mockito.when(exception404.getHttpStatusCode()).thenReturn(404);
+        return bdio2RetryAwareStreamUploader;
+    }
+
+    @NotNull
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnStart(final BlackDuckRequestBuilderEditor editor, final BdioFileContent bdioFileContent)
+        throws IntegrationException {
+        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
         IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
-        Mockito.when(bdio2StreamUploader.start(header, editor)).thenThrow(exception512);
-        // e.getHttpStatusCode()
         Mockito.when(exception512.getHttpStatusCode()).thenReturn(512);
-        bdio2RetryAwareStreamUploader.start(header, editor);
+        Mockito.when(bdio2StreamUploader.start(bdioFileContent, editor)).thenThrow(exception512);
+        return new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
+    }
+
+    @NotNull
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnAppend(final HttpUrl httpUrl, final BdioFileContent bdioFileContent, final BlackDuckRequestBuilderEditor editor)
+        throws IntegrationException {
+        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+        IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
+        Mockito.when(bdio2StreamUploader.append(httpUrl, 1, bdioFileContent, editor)).thenThrow(exception512);
+        Mockito.when(exception512.getHttpStatusCode()).thenReturn(512);
+        return new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
+    }
+
+    @NotNull
+    private Bdio2RetryAwareStreamUploader mockBdio2RetryAwareStreamUploaderThrows512OnFinish(final HttpUrl httpUrl, final BlackDuckRequestBuilderEditor editor)
+        throws IntegrationException {
+        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+        IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
+        Mockito.when(bdio2StreamUploader.finish(httpUrl, 1, editor)).thenThrow(exception512);
+        Mockito.when(exception512.getHttpStatusCode()).thenReturn(512);
+        return new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
     }
 }

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -1,0 +1,30 @@
+package com.synopsys.integration.blackduck.bdio2;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
+import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
+import com.synopsys.integration.rest.response.Response;
+
+public class Bdio2RetryAwareStreamUploaderTest {
+
+    @Test
+    void test() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+        Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = new Bdio2RetryAwareStreamUploader(bdio2StreamUploader);
+
+        BdioFileContent header = Mockito.mock(BdioFileContent.class);
+        BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
+
+        // bdio2StreamUploader.start(header, editor);
+        Response response512 = Mockito.mock(Response.class);
+        IntegrationRestException exception512 = Mockito.mock(IntegrationRestException.class);
+        Mockito.when(bdio2StreamUploader.start(header, editor)).thenThrow(exception512);
+        // e.getHttpStatusCode()
+        Mockito.when(exception512.getHttpStatusCode()).thenReturn(512);
+        bdio2RetryAwareStreamUploader.start(header, editor);
+    }
+}

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -23,8 +23,8 @@ public class Bdio2UploadJobTest {
     private final int waitInterval = 2;
 
     @Test
-    public void testRetryOnFailedHeaderUpload() throws IntegrationException, InterruptedException {
-        Bdio2StreamUploader bdio2StreamUploader = getUploaderThatGets429OnStart();
+    public void testRetryOnFailedHeaderUpload() throws IntegrationException, InterruptedException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatGets429OnStart();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
         Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
@@ -35,14 +35,14 @@ public class Bdio2UploadJobTest {
         return new ResilientJobExecutor(jobConfig);
     }
 
-    private Bdio2UploadJob getUploadJob(Bdio2StreamUploader bdio2StreamUploader) {
+    private Bdio2UploadJob getUploadJob(Bdio2RetryAwareStreamUploader bdio2StreamUploader) {
         BdioFileContent header = new BdioFileContent("bdio-header.jsonld", "");
         BdioFileContent entry = new BdioFileContent("bdio-entry-00.jsonld", "");
         return new Bdio2UploadJob(bdio2StreamUploader, header, Collections.singletonList(entry), null, 2, true, true);
     }
 
-    private Bdio2StreamUploader getUploaderThatGets429OnStart() throws IntegrationException {
-        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+    private Bdio2RetryAwareStreamUploader getUploaderThatGets429OnStart() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
         Response response = Mockito.mock(DefaultResponse.class);
         Mockito.when(response.getStatusCode()).thenReturn(429);
         Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(response);
@@ -51,15 +51,15 @@ public class Bdio2UploadJobTest {
     }
 
     @Test
-    public void testRetryOnFailedChunkUpload() throws IntegrationException, InterruptedException {
-        Bdio2StreamUploader bdio2StreamUploader = getUploaderThatGets429OnAppend();
+    public void testRetryOnFailedChunkUpload() throws IntegrationException, InterruptedException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatGets429OnAppend();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
         Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
     }
 
-    private Bdio2StreamUploader getUploaderThatGets429OnAppend() throws IntegrationException {
-        Bdio2StreamUploader bdio2StreamUploader = Mockito.mock(Bdio2StreamUploader.class);
+    private Bdio2RetryAwareStreamUploader getUploaderThatGets429OnAppend() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
 
         Response failedResponse = Mockito.mock(DefaultResponse.class);
         Mockito.when(failedResponse.getStatusCode()).thenReturn(429);

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -72,8 +72,6 @@ public class Bdio2UploadJobTest {
         Response successResponse = Mockito.mock(Response.class);
         Mockito.when(successResponse.isStatusCodeSuccess()).thenReturn(true);
         Mockito.when(successResponse.getHeaderValue("location")).thenReturn("https://server.blackduck.com/api/endpoint/scanId");
-        //Response failureResponse = Mockito.mock(Response.class);
-        //Mockito.when(failureResponse.isStatusCodeSuccess()).thenReturn(false);
         Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successResponse);
         Mockito.when(bdio2StreamUploader.append(Mockito.any(HttpUrl.class), Mockito.anyInt(), Mockito.any(BdioFileContent.class), Mockito.any(BlackDuckRequestBuilderEditor.class))).thenReturn(successResponse);
         Mockito.when(bdio2StreamUploader.finish(Mockito.any(), Mockito.anyInt(), Mockito.any())).thenThrow(new RetriableBdioUploadException());

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -8,10 +8,15 @@ import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
+import com.synopsys.integration.blackduck.exception.BlackDuckApiException;
+import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.exception.IntegrationTimeoutException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;
+import com.synopsys.integration.rest.HttpMethod;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
 import com.synopsys.integration.rest.response.DefaultResponse;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.wait.ResilientJobConfig;
@@ -23,12 +28,58 @@ public class Bdio2UploadJobTest {
     private final int waitInterval = 2;
 
     @Test
-    public void testRetryOnFailedHeaderUpload() throws IntegrationException, InterruptedException, RetriableBdioUploadException {
-        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatGets429OnStart();
+    public void testRetryOnFailedHeaderUpload() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnStart();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
         Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
     }
+
+    @Test
+    public void testRetryOnFailedChunkUpload() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnAppend();
+        Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
+        ResilientJobExecutor jobExecutor = getJobExecutor();
+        Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
+    }
+
+    @Test
+    public void testRetryOnFailedFinish() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnFinish();
+        Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
+        ResilientJobExecutor jobExecutor = getJobExecutor();
+        Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
+    }
+
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnStart() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenThrow(new RetriableBdioUploadException());
+        return bdio2StreamUploader;
+    }
+
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnAppend() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
+        Response successResponse = Mockito.mock(Response.class);
+        Mockito.when(successResponse.isStatusCodeSuccess()).thenReturn(true);
+        Mockito.when(successResponse.getHeaderValue("location")).thenReturn("https://server.blackduck.com/api/endpoint/scanId");
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successResponse);
+        Mockito.when(bdio2StreamUploader.append(Mockito.any(HttpUrl.class), Mockito.anyInt(), Mockito.any(BdioFileContent.class), Mockito.any(BlackDuckRequestBuilderEditor.class))).thenThrow(new RetriableBdioUploadException());
+        return bdio2StreamUploader;
+    }
+
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnFinish() throws IntegrationException, RetriableBdioUploadException {
+        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
+        Response successResponse = Mockito.mock(Response.class);
+        Mockito.when(successResponse.isStatusCodeSuccess()).thenReturn(true);
+        Mockito.when(successResponse.getHeaderValue("location")).thenReturn("https://server.blackduck.com/api/endpoint/scanId");
+        //Response failureResponse = Mockito.mock(Response.class);
+        //Mockito.when(failureResponse.isStatusCodeSuccess()).thenReturn(false);
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successResponse);
+        Mockito.when(bdio2StreamUploader.append(Mockito.any(HttpUrl.class), Mockito.anyInt(), Mockito.any(BdioFileContent.class), Mockito.any(BlackDuckRequestBuilderEditor.class))).thenReturn(successResponse);
+        Mockito.when(bdio2StreamUploader.finish(Mockito.any(), Mockito.anyInt(), Mockito.any())).thenThrow(new RetriableBdioUploadException());
+        return bdio2StreamUploader;
+    }
+
 
     private ResilientJobExecutor getJobExecutor() {
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, timeout, System.currentTimeMillis(), waitInterval);
@@ -38,37 +89,7 @@ public class Bdio2UploadJobTest {
     private Bdio2UploadJob getUploadJob(Bdio2RetryAwareStreamUploader bdio2StreamUploader) {
         BdioFileContent header = new BdioFileContent("bdio-header.jsonld", "");
         BdioFileContent entry = new BdioFileContent("bdio-entry-00.jsonld", "");
-        return new Bdio2UploadJob(bdio2StreamUploader, header, Collections.singletonList(entry), null, 2, true, true);
-    }
-
-    private Bdio2RetryAwareStreamUploader getUploaderThatGets429OnStart() throws IntegrationException, RetriableBdioUploadException {
-        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
-        Response response = Mockito.mock(DefaultResponse.class);
-        Mockito.when(response.getStatusCode()).thenReturn(429);
-        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(response);
-
-        return bdio2StreamUploader;
-    }
-
-    @Test
-    public void testRetryOnFailedChunkUpload() throws IntegrationException, InterruptedException, RetriableBdioUploadException {
-        Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatGets429OnAppend();
-        Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
-        ResilientJobExecutor jobExecutor = getJobExecutor();
-        Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
-    }
-
-    private Bdio2RetryAwareStreamUploader getUploaderThatGets429OnAppend() throws IntegrationException, RetriableBdioUploadException {
-        Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
-
-        Response failedResponse = Mockito.mock(DefaultResponse.class);
-        Mockito.when(failedResponse.getStatusCode()).thenReturn(429);
-        Response successfulResponse = Mockito.mock(DefaultResponse.class);
-        Mockito.when(successfulResponse.getStatusCode()).thenReturn(200);
-
-        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successfulResponse);
-        Mockito.when(bdio2StreamUploader.append(Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any())).thenReturn(failedResponse);
-
-        return bdio2StreamUploader;
+        BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
+        return new Bdio2UploadJob(bdio2StreamUploader, header, Collections.singletonList(entry), editor, 2, true, true);
     }
 }


### PR DESCRIPTION
Retry IP bdio upload if it fails. (Earlier changes didn't account for the fact that an exception is thrown when there's a failure. With these changes it'll handle the exception case, or the no-exception case, in case integration-rest is changed in the future to not throw exceptions on failure.)