### PR TITLE
IDETECT-3475 | fix to accommodate changes made to the polling mechanism introduced by the separation of the config from the polling | jppetrakis

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -25,6 +25,8 @@ import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.util.NameVersion;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.ResilientJobExecutor;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 public class Bdio2FileUploadService extends DataService {
     private static final String FILE_NAME_BDIO_HEADER_JSONLD = "bdio-header.jsonld";
@@ -80,7 +82,8 @@ public class Bdio2FileUploadService extends DataService {
                 .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
         }
 
-        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, timeout, System.currentTimeMillis(), BD_WAIT_AND_RETRY_INTERVAL);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, BD_WAIT_AND_RETRY_INTERVAL);
+        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);
         Bdio2UploadJob bdio2UploadJob = new Bdio2UploadJob(bdio2RetryAwareStreamUploader, header, remainingFiles, editor, count, shouldUploadEntries, shouldFinishUpload);
         ResilientJobExecutor jobExecutor = new ResilientJobExecutor(jobConfig);
 

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaiter.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaiter.java
@@ -21,6 +21,8 @@ import com.synopsys.integration.util.NameVersion;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.ResilientJobExecutor;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 public class CodeLocationWaiter {
     private final IntLogger logger;
@@ -42,7 +44,8 @@ public class CodeLocationWaiter {
         codeLocationNames.forEach(codeLocation -> logger.debug(String.format("  Code Location -> %s", codeLocation)));
         logger.debug("");
 
-        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, timeoutInSeconds, notificationTaskRange.getTaskStartTime(), waitIntervalInSeconds);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeoutInSeconds, waitIntervalInSeconds);
+        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, notificationTaskRange.getTaskStartTime(), waitIntervalTracker);
 
 
         CodeLocationWaitJob codeLocationWaitJob = new CodeLocationWaitJob(logger, projectService, notificationService, userView, notificationTaskRange, projectAndVersion, codeLocationNames,

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -21,6 +21,8 @@ import com.synopsys.integration.rest.response.DefaultResponse;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.ResilientJobExecutor;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 public class Bdio2UploadJobTest {
     private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(this.getClass()));
@@ -80,7 +82,8 @@ public class Bdio2UploadJobTest {
 
 
     private ResilientJobExecutor getJobExecutor() {
-        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, timeout, System.currentTimeMillis(), waitInterval);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, waitInterval);
+        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);
         return new ResilientJobExecutor(jobConfig);
     }
 

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/CreateProjectWithBdioAndVerifyBOMTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/CreateProjectWithBdioAndVerifyBOMTest.java
@@ -45,6 +45,8 @@ import com.synopsys.integration.util.NameVersion;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
 import com.synopsys.integration.wait.WaitJobCondition;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag("integration")
 @ExtendWith(TimingExtension.class)
@@ -72,7 +74,8 @@ public class CreateProjectWithBdioAndVerifyBOMTest {
     private final BlackDuckServices blackDuckServices = new BlackDuckServices(intHttpClientTestHelper);
     private final UserView currentUser = blackDuckServices.userService.findCurrentUser();
     private final IntLogger waitLogger = new PrintStreamIntLogger(System.out, LogLevel.DEBUG);
-    private final ResilientJobConfig jobbyConfig = new ResilientJobConfig(waitLogger, TEN_MINUTES, ResilientJobConfig.CURRENT_TIME_SUPPLIER, THIRTY_SECONDS);
+    WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(TEN_MINUTES, THIRTY_SECONDS);
+    private final ResilientJobConfig jobbyConfig = new ResilientJobConfig(waitLogger, ResilientJobConfig.CURRENT_TIME_SUPPLIER, waitIntervalTracker);
     private final Predicate<CodeLocationView> shouldDeleteCodeLocation = (codeLocationView -> CODE_LOCATION_NAMES.contains(codeLocationView.getName()));
 
     public CreateProjectWithBdioAndVerifyBOMTest() throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/InstallAndRunSignatureScannerTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/InstallAndRunSignatureScannerTestIT.java
@@ -52,6 +52,8 @@ import com.synopsys.integration.util.IntEnvironmentVariables;
 import com.synopsys.integration.util.OperatingSystemType;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag("integration")
 @ExtendWith(TimingExtension.class)
@@ -136,7 +138,8 @@ class InstallAndRunSignatureScannerTestIT {
         // finally, verify the code location exists and then delete it to clean up
         CodeLocationService codeLocationService = blackDuckServicesFactory.createCodeLocationService();
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
-        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, 120, System.currentTimeMillis(), 10);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(120, 10);
+        ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);
         WaitJob.waitFor(jobConfig, () -> codeLocationService.getCodeLocationByName(CODE_LOCATION_NAME).isPresent(), "codeLocationTest");
 
         Optional<CodeLocationView> codeLocationViewOptional = codeLocationService.getCodeLocationByName(CODE_LOCATION_NAME);

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/recipe/BdioUploadRecipeTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/recipe/BdioUploadRecipeTest.java
@@ -32,6 +32,8 @@ import com.synopsys.integration.rest.RestConstants;
 import com.synopsys.integration.util.NameVersion;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag("integration")
 @ExtendWith(TimingExtension.class)
@@ -134,7 +136,8 @@ public class BdioUploadRecipeTest extends BasicRecipe {
         if (optionalCodeLocationView.isPresent()) {
             deleteCodeLocation(codeLocationName);
         }
-        ResilientJobConfig waitJobConfig = new ResilientJobConfig(logger, 30, ResilientJobConfig.CURRENT_TIME_SUPPLIER, 5);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(30, 5);
+        ResilientJobConfig waitJobConfig = new ResilientJobConfig(logger, ResilientJobConfig.CURRENT_TIME_SUPPLIER, waitIntervalTracker);
         WaitJob.waitFor(waitJobConfig, () -> !codeLocationService.getCodeLocationByName(codeLocationName).isPresent(), "code location not found");
     }
 


### PR DESCRIPTION
Needed to use the new poll tracker and constructor for the config class.