### PR TITLE
add reduced persistence flags for signature scans

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.BlackDuckOnlineProperties;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
+import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanCommand;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanPathsUtility;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanTarget;
@@ -54,11 +55,12 @@ public class ScanBatch extends Stringable implements Buildable {
     private final boolean debug;
     private final boolean verbose;
     private final boolean isRapid;
+    private final ReducedPersistence reducedPersistence;
 
     public ScanBatch(File outputDirectory, boolean cleanupOutput, int scanMemoryInMegabytes, boolean dryRun, boolean debug, boolean verbose,
         String scanCliOpts, String additionalScanArguments, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, HttpUrl blackDuckUrl,
         String blackDuckUsername, String blackDuckPassword, String blackDuckApiToken, ProxyInfo proxyInfo, boolean runInsecure, String projectName, String projectVersionName,
-        List<ScanTarget> scanTargets, boolean isRapid) {
+        List<ScanTarget> scanTargets, boolean isRapid, ReducedPersistence reducedPersistence) {
         this.outputDirectory = outputDirectory;
         this.cleanupOutput = cleanupOutput;
         this.scanMemoryInMegabytes = scanMemoryInMegabytes;
@@ -79,6 +81,7 @@ public class ScanBatch extends Stringable implements Buildable {
         this.projectVersionName = projectVersionName;
         this.scanTargets = scanTargets;
         this.isRapid = isRapid;
+        this.reducedPersistence = reducedPersistence;
     }
 
     /**
@@ -119,7 +122,7 @@ public class ScanBatch extends Stringable implements Buildable {
         File commandOutputDirectory = scanTarget.determineCommandOutputDirectory(scanPathsUtility, outputDirectory);
         ScanCommand scanCommand = new ScanCommand(signatureScannerInstallDirectory, commandOutputDirectory, commandDryRun, proxyInfo, scanCliOptsToUse, scanMemoryInMegabytes, commandScheme, commandHost,
             blackDuckApiToken, blackDuckUsername, blackDuckPassword, commandPort, runInsecure, scanTarget.getCodeLocationName(), blackDuckOnlineProperties,
-            individualFileMatching, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, isRapid);
+            individualFileMatching, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, isRapid, reducedPersistence);
         scanCommands.add(scanCommand);
     }
 
@@ -209,6 +212,10 @@ public class ScanBatch extends Stringable implements Buildable {
 
     public boolean isRapid() {
         return isRapid;
+    }
+    
+    public ReducedPersistence getReducedPersistence() {
+        return reducedPersistence;
     }
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.BlackDuckOnlineProperties;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
+import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanTarget;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
@@ -55,6 +56,7 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private String projectVersionName;
 
     private boolean isRapid;
+    private ReducedPersistence reducedPersistence;
 
     private List<ScanTarget> scanTargets = new ArrayList<>();
 
@@ -63,7 +65,7 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
         BlackDuckOnlineProperties blackDuckOnlineProperties = new BlackDuckOnlineProperties(snippetMatching, uploadSource, licenseSearch, copyrightSearch);
         return new ScanBatch(outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments,
             blackDuckOnlineProperties, individualFileMatching, blackDuckUrl, blackDuckUsername, blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate,
-            projectName, projectVersionName, scanTargets, isRapid);
+            projectName, projectVersionName, scanTargets, isRapid, reducedPersistence);
     }
 
     @Override
@@ -350,6 +352,14 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     public ScanBatchBuilder simpleScanTargets(List<ScanTarget> scanTargets) {
         this.scanTargets = scanTargets;
         return this;
+    }
+
+	public void reducedPersistence(ReducedPersistence reducedPersistence) {
+		this.reducedPersistence = reducedPersistence;		
+	}
+	
+    public ReducedPersistence getReducedPersistence() {
+        return reducedPersistence;
     }
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ReducedPersistence.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ReducedPersistence.java
@@ -1,0 +1,13 @@
+/*
+ * blackduck-common
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.codelocation.signaturescanner.command;
+
+public enum ReducedPersistence {
+	RETAIN_UNMATCHED,
+	DISCARD_UNMATCHED
+}

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -46,10 +46,11 @@ public class ScanCommand {
     private final boolean debug;
     private final boolean verbose;
     private final boolean isRapid;
+    private final ReducedPersistence reducedPersistence;
 
     public ScanCommand(File signatureScannerInstallDirectory, File outputDirectory, boolean dryRun, ProxyInfo proxyInfo, String scanCliOpts, int scanMemoryInMegabytes, String scheme, String host, String blackDuckApiToken,
         String blackDuckUsername, String blackDuckPassword, int port, boolean runInsecure, String name, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, Set<String> excludePatterns,
-        String additionalScanArguments, String targetPath, boolean verbose, boolean debug, String projectName, String versionName, boolean isRapid) {
+        String additionalScanArguments, String targetPath, boolean verbose, boolean debug, String projectName, String versionName, boolean isRapid, ReducedPersistence reducedPersistence) {
         this.signatureScannerInstallDirectory = signatureScannerInstallDirectory;
         this.outputDirectory = outputDirectory;
         this.dryRun = dryRun;
@@ -74,6 +75,7 @@ public class ScanCommand {
         this.projectName = projectName;
         this.versionName = versionName;
         this.isRapid = isRapid;
+        this.reducedPersistence = reducedPersistence;
     }
 
     public List<String> createCommandForProcessBuilder(IntLogger logger, ScanPaths scannerPaths, String specificRunOutputDirectoryPath) throws IllegalArgumentException, IntegrationException {
@@ -132,11 +134,24 @@ public class ScanCommand {
             cmd.add("--no-persistence");
         }
 
+        populateReducedPersistence(cmd);
+        
         ScanCommandArgumentParser parser = new ScanCommandArgumentParser();
         populateAdditionalScanArguments(cmd, parser);
 
         return cmd;
     }
+
+	private void populateReducedPersistence(List<String> cmd) {
+		if (reducedPersistence != null) {
+        	if (reducedPersistence.equals(ReducedPersistence.DISCARD_UNMATCHED)) {
+        		cmd.add("--discard-unmatched-files");
+        	}
+        	if (reducedPersistence.equals(ReducedPersistence.RETAIN_UNMATCHED)) {
+        		cmd.add("--retain-unmatched-files");
+        	}
+        }
+	}
 
     private void populateAdditionalScanArguments(List<String> cmd, ScanCommandArgumentParser parser) throws IntegrationException {
         List<String> arguments = parser.parse(additionalScanArguments);
@@ -354,6 +369,10 @@ public class ScanCommand {
 
     public boolean isRapid() {
         return isRapid;
+    }
+    
+    public ReducedPersistence getReducedPersistence() {
+        return reducedPersistence;
     }
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -142,16 +142,16 @@ public class ScanCommand {
         return cmd;
     }
 
-	private void populateReducedPersistence(List<String> cmd) {
-		if (reducedPersistence != null) {
-        	if (reducedPersistence.equals(ReducedPersistence.DISCARD_UNMATCHED)) {
-        		cmd.add("--discard-unmatched-files");
-        	}
-        	if (reducedPersistence.equals(ReducedPersistence.RETAIN_UNMATCHED)) {
-        		cmd.add("--retain-unmatched-files");
-        	}
+    private void populateReducedPersistence(List<String> cmd) {
+        if (reducedPersistence != null) {
+            if (reducedPersistence.equals(ReducedPersistence.DISCARD_UNMATCHED)) {
+                cmd.add("--discard-unmatched-files");
+            }
+            if (reducedPersistence.equals(ReducedPersistence.RETAIN_UNMATCHED)) {
+                cmd.add("--retain-unmatched-files");
+            }
         }
-	}
+    }
 
     private void populateAdditionalScanArguments(List<String> cmd, ScanCommandArgumentParser parser) throws IntegrationException {
         List<String> arguments = parser.parse(additionalScanArguments);

--- a/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
@@ -186,6 +186,20 @@ public class ScanCommandTest {
     	List<String> commandList = createCommandList();
     	assertFalse(commandList.contains("--no-persistence"));
     }
+    
+    @Test
+    public void testRetainUnmatchedFiles() throws IntegrationException {
+    	scanBatchBuilder.reducedPersistence(ReducedPersistence.RETAIN_UNMATCHED);
+    	List<String> commandList = createCommandList();
+    	assertTrue(commandList.contains("--retain-unmatched-files"));
+    }
+    
+    @Test
+    public void testDiscardUnmatchedFiles() throws IntegrationException {
+    	scanBatchBuilder.reducedPersistence(ReducedPersistence.DISCARD_UNMATCHED);
+    	List<String> commandList = createCommandList();
+    	assertTrue(commandList.contains("--discard-unmatched-files"));
+    }
 
     private void populateBuilder(ScanBatchBuilder scanBatchBuilder) {
         try {


### PR DESCRIPTION
Adds flags to allow users to specify if unmatched files should be persisted or purged when running signature scans. This aligns with new features in BlackDuck 2022.10