### PR TITLE
Allow downstream clients to use the dependency scope field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,14 @@ versionFile << version
 
 repositories {
     maven { url "https://sig-repo.synopsys.com/bds-bdio-release" }
+    mavenLocal()
 }
 
 dependencies {
     api 'com.synopsys.integration:blackduck-common-api:2022.10.4'
     api 'com.synopsys.integration:phone-home-client:5.1.7'
 
-    api 'com.synopsys.integration:integration-bdio:26.0.7'
+    api 'com.synopsys.integration:integration-bdio:26.0.8-SNAPSHOT'
     api 'com.blackducksoftware.bdio:bdio2:3.2.5'
 
 

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Factory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Factory.java
@@ -179,7 +179,13 @@ public class Bdio2Factory {
                 }
             } else {
                 Component component = componentFromDependency(dependency);
-                linkComponentDependency.dependency(new com.blackducksoftware.bdio2.model.Dependency().dependsOn(component));
+                com.blackducksoftware.bdio2.model.Dependency dependencyEntry = new com.blackducksoftware.bdio2.model.Dependency().dependsOn(component);
+
+                if (dependency.getScope() != null) {
+                    dependencyEntry = dependencyEntry.scope(dependency.getScope());
+                }
+
+                linkComponentDependency.dependency(dependencyEntry);
 
                 if (!existingComponents.containsKey(dependency.getExternalId())) {
                     addedComponents.add(component);

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2FactoryTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2FactoryTest.java
@@ -44,7 +44,7 @@ class Bdio2FactoryTest {
         DependencyGraph dependencyGraph = Mockito.mock(DependencyGraph.class);
         Set<Dependency> dependencies = new HashSet<>();
         ProjectDependency subProjectDependency = new ProjectDependency(subProjectName, subProjectVersion, subProjectExternalId);
-        Dependency componentDependency = new Dependency(componentExternalId);
+        Dependency componentDependency = new Dependency(componentExternalId, null);
         dependencies.add(subProjectDependency);
         dependencies.add(componentDependency);
         Mockito.when(dependencyGraph.getDirectDependencies()).thenReturn(dependencies);


### PR DESCRIPTION
Add use of the dependency scope field when generating BDIO dependency representations