### PR TITLE
do not send http headers with project name or version name

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.blackduck.bdio2;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -76,11 +78,17 @@ public class Bdio2FileUploadService extends DataService {
         logger.debug("BDIO upload file count = " + count);
 
         BlackDuckRequestBuilderEditor editor = noOp -> {};
-        if (nameVersion != null) {
-            editor = builder -> builder
-                .addHeader(Bdio2StreamUploader.PROJECT_NAME_HEADER, nameVersion.getName())
-                .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
-        }
+//        if (nameVersion != null) {
+//            editor = (builder -> {
+//            	// TODO can't send non-ascii characters. Have to encode and have client and server agree on
+//            	// encoding. I think BD was moving away from these HTTP headers. Maybe we can just get things from
+//            	// the BDIO header file?
+//            	
+//            	builder
+//                .addHeader(Bdio2StreamUploader.PROJECT_NAME_HEADER, nameVersion.getName())
+//                .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
+//            });
+//        }
 
         WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, BD_WAIT_AND_RETRY_INTERVAL);
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -7,8 +7,6 @@
  */
 package com.synopsys.integration.blackduck.bdio2;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,17 +76,6 @@ public class Bdio2FileUploadService extends DataService {
         logger.debug("BDIO upload file count = " + count);
 
         BlackDuckRequestBuilderEditor editor = noOp -> {};
-//        if (nameVersion != null) {
-//            editor = (builder -> {
-//            	// TODO can't send non-ascii characters. Have to encode and have client and server agree on
-//            	// encoding. I think BD was moving away from these HTTP headers. Maybe we can just get things from
-//            	// the BDIO header file?
-//            	
-//            	builder
-//                .addHeader(Bdio2StreamUploader.PROJECT_NAME_HEADER, nameVersion.getName())
-//                .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
-//            });
-//        }
 
         WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, BD_WAIT_AND_RETRY_INTERVAL);
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);


### PR DESCRIPTION
Attempting to create intelligent persistent scans with project names or versions containing non-ASCII characters results in 400 errors from the Black Duck nginx server. I believe this is because the spec does not allow for non-ASCII characters in headers. Ideally we would a) put this information in the BDIO header, which detect currently does, and have Black Duck get the information from there or b) encode the http headers and have Black Duck decode them.

From my experiments with various Black Duck servers going back to 2022.4.3, removing the http headers seems to work fine. I'm able to see projects, versions, and code locations with non-ASCII characters and the BOM contains the same data if I scan the same source and provide only ASCII characters for these names. It maybe be for the involved endpoint, /api/intelligent-persistence-scans, that Black Duck is obtaining these names from somewhere, perhaps the BDIO header, already.