### PR TITLE
version check for http headers

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -95,8 +95,8 @@ public class Bdio2FileUploadService extends DataService {
     // project names and version names and do not need the REST headers which can have issues
     // with non-ASCII characters.
 	private boolean useOnlyBdioHeaders() {
-		if (blackDuckApiClient.getBlackDuckVersion() != null) {
-			BlackDuckVersion currentBlackDuckVersion = blackDuckApiClient.getBlackDuckVersion();
+		if (blackDuckApiClient.getBlackDuckVersion().isPresent()) {
+			BlackDuckVersion currentBlackDuckVersion = blackDuckApiClient.getBlackDuckVersion().get();
 			BlackDuckVersion requiresBdioHeadersVersion = new BlackDuckVersion(2023, 4, 1);
 			
 			return currentBlackDuckVersion.isAtLeast(requiresBdioHeadersVersion);

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -20,6 +20,7 @@ import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationExceptio
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.DataService;
 import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
+import com.synopsys.integration.blackduck.version.BlackDuckVersion;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.util.NameVersion;
@@ -76,6 +77,11 @@ public class Bdio2FileUploadService extends DataService {
         logger.debug("BDIO upload file count = " + count);
 
         BlackDuckRequestBuilderEditor editor = noOp -> {};
+        if (nameVersion != null && !useOnlyBdioHeaders()) {
+            editor = builder -> builder
+                .addHeader(Bdio2StreamUploader.PROJECT_NAME_HEADER, nameVersion.getName())
+                .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
+        }
 
         WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, BD_WAIT_AND_RETRY_INTERVAL);
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);
@@ -84,5 +90,19 @@ public class Bdio2FileUploadService extends DataService {
 
         return jobExecutor.executeJob(bdio2UploadJob);
     }
+
+    // BlackDuck servers 2023.4.1 and later can use only BDIO header information for 
+    // project names and version names and do not need the REST headers which can have issues
+    // with non-ASCII characters.
+	private boolean useOnlyBdioHeaders() {
+		if (blackDuckApiClient.getBlackDuckVersion() != null) {
+			BlackDuckVersion currentBlackDuckVersion = blackDuckApiClient.getBlackDuckVersion();
+			BlackDuckVersion requiresBdioHeadersVersion = new BlackDuckVersion(2023, 4, 1);
+			
+			return currentBlackDuckVersion.isAtLeast(requiresBdioHeadersVersion);
+		}
+        	
+		return false;
+	}
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.blackduck.service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
@@ -42,7 +43,7 @@ public class BlackDuckApiClient {
     private final BlackDuckResponsesTransformer blackDuckResponsesTransformer;
     private BlackDuckVersion blackDuckVersion;
 
-	public BlackDuckApiClient(BlackDuckHttpClient blackDuckHttpClient, BlackDuckJsonTransformer blackDuckJsonTransformer, BlackDuckResponseTransformer blackDuckResponseTransformer,
+    public BlackDuckApiClient(BlackDuckHttpClient blackDuckHttpClient, BlackDuckJsonTransformer blackDuckJsonTransformer, BlackDuckResponseTransformer blackDuckResponseTransformer,
         BlackDuckResponsesTransformer blackDuckResponsesTransformer) {
         this.blackDuckHttpClient = blackDuckHttpClient;
         this.blackDuckJsonTransformer = blackDuckJsonTransformer;
@@ -169,13 +170,13 @@ public class BlackDuckApiClient {
         }
     }
     
-    public BlackDuckVersion getBlackDuckVersion() {
-		return blackDuckVersion;
-	}
+    public Optional<BlackDuckVersion> getBlackDuckVersion() {
+        return Optional.ofNullable(blackDuckVersion);
+    }
     
-	public void setBlackDuckVersion(BlackDuckVersion blackDuckVersion) {
-		this.blackDuckVersion = blackDuckVersion;
-	}
+    public void setBlackDuckVersion(BlackDuckVersion blackDuckVersion) {
+        this.blackDuckVersion = blackDuckVersion;
+    }
 
     private BlackDuckRequestBuilder createCommonGetRequestBuilder(HttpUrl url) {
         return new BlackDuckRequestBuilder().url(url);

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -25,6 +25,7 @@ import com.synopsys.integration.blackduck.http.transform.BlackDuckResponseTransf
 import com.synopsys.integration.blackduck.http.transform.BlackDuckResponsesTransformer;
 import com.synopsys.integration.blackduck.service.request.BlackDuckRequest;
 import com.synopsys.integration.blackduck.service.request.BlackDuckResponseRequest;
+import com.synopsys.integration.blackduck.version.BlackDuckVersion;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
@@ -39,13 +40,15 @@ public class BlackDuckApiClient {
     private final BlackDuckJsonTransformer blackDuckJsonTransformer;
     private final BlackDuckResponseTransformer blackDuckResponseTransformer;
     private final BlackDuckResponsesTransformer blackDuckResponsesTransformer;
+    private BlackDuckVersion blackDuckVersion;
 
-    public BlackDuckApiClient(BlackDuckHttpClient blackDuckHttpClient, BlackDuckJsonTransformer blackDuckJsonTransformer, BlackDuckResponseTransformer blackDuckResponseTransformer,
+	public BlackDuckApiClient(BlackDuckHttpClient blackDuckHttpClient, BlackDuckJsonTransformer blackDuckJsonTransformer, BlackDuckResponseTransformer blackDuckResponseTransformer,
         BlackDuckResponsesTransformer blackDuckResponsesTransformer) {
         this.blackDuckHttpClient = blackDuckHttpClient;
         this.blackDuckJsonTransformer = blackDuckJsonTransformer;
         this.blackDuckResponseTransformer = blackDuckResponseTransformer;
         this.blackDuckResponsesTransformer = blackDuckResponsesTransformer;
+        this.blackDuckVersion = null;
     }
 
     public <T extends BlackDuckResponse> List<T> getAllResponses(UrlMultipleResponses<T> urlMultipleResponses) throws IntegrationException {
@@ -165,6 +168,14 @@ public class BlackDuckApiClient {
             throw new IntegrationException(e.getMessage(), e);
         }
     }
+    
+    public BlackDuckVersion getBlackDuckVersion() {
+		return blackDuckVersion;
+	}
+    
+	public void setBlackDuckVersion(BlackDuckVersion blackDuckVersion) {
+		this.blackDuckVersion = blackDuckVersion;
+	}
 
     private BlackDuckRequestBuilder createCommonGetRequestBuilder(HttpUrl url) {
         return new BlackDuckRequestBuilder().url(url);

--- a/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
+++ b/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
@@ -1,0 +1,49 @@
+package com.synopsys.integration.blackduck.version;
+
+import com.synopsys.integration.util.Stringable;
+
+public class BlackDuckVersion extends Stringable {
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    public BlackDuckVersion(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    public boolean isAtLeast(BlackDuckVersion other) {
+        if (major > other.getMajor()) {
+            return true;
+        }
+        if (major < other.getMajor()) {
+            return false;
+        }
+        if (minor > other.getMinor()) {
+            return true;
+        }
+        if (minor < other.getMinor()) {
+            return false;
+        }
+        if (patch > other.getPatch()) {
+            return true;
+        }
+        if (patch < other.getPatch()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
+++ b/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
@@ -25,6 +25,14 @@ public class BlackDuckVersion extends Stringable {
         return patch;
     }
 
+	/**
+	 * Compares this version of BlackDuck with the one in the other parameter.
+	 * 
+	 * @param other the BlackDuck version to compare to this one.
+	 * @return returns true if the other BlackDuck version is equal to (has the same
+	 *         major, minor, and patch) or later (is a greater version according to
+	 *         SemVer). Returns false otherwise.
+	 */
     public boolean isAtLeast(BlackDuckVersion other) {
         if (major > other.getMajor()) {
             return true;

--- a/src/test/java/com/synopsys/integration/blackduck/version/BlackDuckVersionTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/version/BlackDuckVersionTest.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.blackduck.version;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.synopsys.integration.blackduck.version.BlackDuckVersion;
+
+import org.junit.jupiter.api.Test;
+
+public class BlackDuckVersionTest {
+
+    @Test
+    void test() {
+        // Different major
+        assertTrue((new BlackDuckVersion(2022, 10, 0)).isAtLeast((new BlackDuckVersion(2021, 1, 0))));
+        assertFalse((new BlackDuckVersion(2021, 10, 0)).isAtLeast((new BlackDuckVersion(2022, 1, 0))));
+
+        // Different minor
+        assertTrue((new BlackDuckVersion(2022, 2, 0)).isAtLeast((new BlackDuckVersion(2022, 1, 0))));
+        assertFalse((new BlackDuckVersion(2022, 1, 0)).isAtLeast((new BlackDuckVersion(2022, 2, 0))));
+
+        // Different patch
+        assertTrue((new BlackDuckVersion(2022, 2, 1)).isAtLeast((new BlackDuckVersion(2022, 2, 0))));
+        assertFalse((new BlackDuckVersion(2022, 2, 1)).isAtLeast((new BlackDuckVersion(2022, 2, 2))));
+
+        // Same
+        assertTrue((new BlackDuckVersion(2022, 2, 1)).isAtLeast((new BlackDuckVersion(2022, 2, 1))));
+    }
+}


### PR DESCRIPTION
This work moves the version class files from the main detect code to this library. This allows us to have version checks at various levels of the code which more use cases are deeming necessary.

The version checks in this PR are then used to determine if we can safely omit the HTTP headers for project names and project versions as BD will pick up these values from the BDIO header instead. This fixes cases where non-ASCII characters were previously supplied in the HTTP headers causing REST calls to fail.

Note: this only conditionally adds REST headers for uploading intelligent persistent related BDIO files. It does not alter all areas where REST headers are used.