### PR TITLE
Need to send content type header when issuing PUTs to newer endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.synopsys.integration:blackduck-common-api:2023.4.0.1'
+    api 'com.synopsys.integration:blackduck-common-api:2023.4.2.1'
     api 'com.synopsys.integration:phone-home-client:5.1.10'
     api 'com.synopsys.integration:integration-bdio:26.0.9'
     api 'com.blackducksoftware.bdio:bdio2:3.2.5'

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -45,7 +45,7 @@ public class BlackDuckApiClient {
     private final BlackDuckResponseTransformer blackDuckResponseTransformer;
     private final BlackDuckResponsesTransformer blackDuckResponsesTransformer;
     private BlackDuckVersion blackDuckVersion;
-	private BlackDuckMediaTypeDiscovery blackDuckMediaTypeDiscovery;
+    private BlackDuckMediaTypeDiscovery blackDuckMediaTypeDiscovery;
 
     public BlackDuckApiClient(BlackDuckHttpClient blackDuckHttpClient, BlackDuckJsonTransformer blackDuckJsonTransformer, BlackDuckResponseTransformer blackDuckResponseTransformer,
         BlackDuckResponsesTransformer blackDuckResponsesTransformer) {

--- a/src/test/java/com/synopsys/integration/blackduck/service/BlackDuckApiClientTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/BlackDuckApiClientTestIT.java
@@ -81,7 +81,7 @@ public class BlackDuckApiClientTestIT {
         BlackDuckSingleRequest<ProjectView> requestSingle = new BlackDuckSingleRequest<>(blackDuckRequestBuilder, projectViewUrlSingleResponse, new PagingDefaultsEditor(), new AcceptHeaderEditor(blackDuckMediaTypeDiscoveryVerifier));
         ProjectView retrievedById = blackDuckApiClient.getResponse(requestSingle);
         assertEquals(null, blackDuckMediaTypeDiscoveryVerifier.originalMediaType);
-        assertEquals("application/vnd.blackducksoftware.project-detail-5+json", blackDuckMediaTypeDiscoveryVerifier.discoveredMediaType);
+        assertEquals("application/vnd.blackducksoftware.project-detail-6+json", blackDuckMediaTypeDiscoveryVerifier.discoveredMediaType);
     }
 
     private class BlackDuckMediaTypeDiscoveryVerifier extends BlackDuckMediaTypeDiscovery {

--- a/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/dataservice/ProjectServiceTestIT.java
@@ -165,7 +165,9 @@ public class ProjectServiceTestIT {
         assertTrue(2 == ProjectServiceTestIT.project.getProjectTier());
         assertEquals("Initial Description", ProjectServiceTestIT.project.getDescription());
 
-        ProjectServiceTestIT.project.setName("New Name");
+        String newProjectName = "New Name";
+        ProjectServiceTestIT.project.setName(newProjectName);
+        deleteProjectIfExists(newProjectName);
         ProjectServiceTestIT.project.setProjectTier(4);
         ProjectServiceTestIT.project.setDescription("New Description");
         ProjectServiceTestIT.blackDuckApiClient.put(ProjectServiceTestIT.project);


### PR DESCRIPTION
Newer generations of blackduck-common-api have moved us to using v6 endpoints. This appears to be a problem when PUTting projects. 

What's happening is that we send an Accept header of application/vnd.blackducksoftware.project-detail-6+json which seems to trigger different code than sending an Accept header of application/vnd.blackducksoftware.project-detail-5+json. The BlackDuck team has informed us that when triggering the v6 code they require a Content-Type header (or else we get 406 errors claiming they don't know what media type our data is in). 

What I'm doing here is sending the media type associated with the endpoint in the PUT request, just like what we do with the Accept header. This works well for the use cases I've been testing but would be interested in thoughts.