### PR TITLE
Return additional REST response information

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -166,6 +166,10 @@ public class BlackDuckApiClient {
         blackDuckHttpClient.throwExceptionForError(response);
         return response;
     }
+    
+    public Response executeAndRetrieveResponse(BlackDuckResponseRequest request) throws IntegrationException {
+        return blackDuckHttpClient.execute(request);
+    }
 
     // ------------------------------------------------
     // posting and getting location header


### PR DESCRIPTION
The current calls to BlackDuck hide some of the information that callers need to determine what to do next. For example, they do not return the headers from a call when it is not a successful call. This prevents Detect from intelligently retrying calls since the Retry-After header is missing.

This is a simple fix to return the raw response from BlackDuck to callers.