### PR TITLE
Enhance retry mechanism for scan starts when BlackDuck specifies retry-after header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ project.ext.moduleName = 'com.synopsys.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '66.2.9-SNAPSHOT-f'
+version = '66.2.9-SNAPSHOT'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ project.ext.moduleName = 'com.synopsys.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '66.2.9-SNAPSHOT'
+version = '66.2.9-SNAPSHOT-f'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -85,7 +85,7 @@ public class Bdio2FileUploadService extends DataService {
 
         WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(timeout, BD_WAIT_AND_RETRY_INTERVAL);
         ResilientJobConfig jobConfig = new ResilientJobConfig(logger, System.currentTimeMillis(), waitIntervalTracker);
-        Bdio2UploadJob bdio2UploadJob = new Bdio2UploadJob(bdio2RetryAwareStreamUploader, header, remainingFiles, editor, count, shouldUploadEntries, shouldFinishUpload, timeout, clientStartTime);
+        Bdio2UploadJob bdio2UploadJob = new Bdio2UploadJob(bdio2RetryAwareStreamUploader, header, remainingFiles, editor, count, shouldUploadEntries, shouldFinishUpload, clientStartTime, timeout);
         ResilientJobExecutor jobExecutor = new ResilientJobExecutor(jobConfig);
 
         return jobExecutor.executeJob(bdio2UploadJob);

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -64,7 +64,7 @@ public class Bdio2RetryAwareStreamUploader {
         return response;
     }
     
-    public void onErrorThrowRetryableOrFailure(Response response) throws IntegrationException, RetriableBdioUploadException, InterruptedException {
+    public void onErrorThrowRetryableOrFailure(Response response, long clientStartTime, long detectTimeout) throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         if (!response.isStatusCodeSuccess()) {
             if (isRetryableExitCode(response.getStatusCode())) {
                 logger.trace("Response status code {} is retryable", response.getStatusCode());
@@ -87,7 +87,7 @@ public class Bdio2RetryAwareStreamUploader {
     
     private boolean isDetectTimeoutExceededBy(long startTime, long waitInMillis, long detectTimeout) {
         long currentTime = System.currentTimeMillis();
-        return (currentTime - startTime + waitInMillis) > detectTimeout;
+        return (currentTime - startTime + waitInMillis) > (detectTimeout * 1000);
     }
 
     private Response translateRetryableExceptions(final IntegrationRestException e) throws RetriableBdioUploadException, IntegrationRestException {

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -81,7 +81,7 @@ public class Bdio2RetryAwareStreamUploader {
         }
         return response;
     }
-    
+
     public void onErrorThrowRetryableOrFailure(Response response) throws IntegrationException, RetriableBdioUploadException {
         if (!response.isStatusCodeSuccess()) {
             if (isRetryableExitCode(response.getStatusCode())) {

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -22,7 +22,7 @@ import com.synopsys.integration.rest.exception.IntegrationRestException;
 import com.synopsys.integration.rest.response.Response;
 
 public class Bdio2RetryAwareStreamUploader {
-    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 500);
+    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404);
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final Bdio2StreamUploader bdio2StreamUploader;
 

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2StreamUploader.java
@@ -58,7 +58,7 @@ public class Bdio2StreamUploader {
             .addHeader(HEADER_CONTENT_TYPE, contentType)
             .apply(editor)
             .buildBlackDuckResponseRequest(url);
-        return blackDuckApiClient.execute(request);
+        return blackDuckApiClient.executeAndRetrieveResponse(request);
     }
 
     public Response append(HttpUrl url, int count, BdioFileContent bdioFileContent, BlackDuckRequestBuilderEditor editor) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
@@ -63,8 +63,8 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
     @Override
     public void attemptJob() throws IntegrationException {
         try {
-            Response headerResponse = bdio2RetryAwareStreamUploader.start(header, editor);
-            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(headerResponse, startTime, timeout);
+            Response headerResponse = bdio2RetryAwareStreamUploader.start(header, editor, startTime, timeout);
+            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(headerResponse);
             complete = true;
             uploadUrl = new HttpUrl(headerResponse.getHeaderValue("location"));
             scanId = parseScanIdFromUploadUrl(uploadUrl.string());
@@ -72,12 +72,12 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
                 logger.debug(String.format("Starting upload to %s", uploadUrl.string()));
                 for (BdioFileContent content : bdioEntries) {
                     Response chunkResponse = bdio2RetryAwareStreamUploader.append(uploadUrl, count, content, editor);
-                    bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(chunkResponse, startTime, timeout);
+                    bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(chunkResponse);
                 }
             }
             if (shouldFinishUpload) {
                 Response finishResponse = bdio2RetryAwareStreamUploader.finish(uploadUrl, count, editor);
-                bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(finishResponse, startTime, timeout);
+                bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(finishResponse);
             }
         } catch (RetriableBdioUploadException | InterruptedException e) {
             complete = false;

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
@@ -73,7 +73,7 @@ public class Bdio2UploadJob implements ResilientJob<Bdio2UploadResult> {
                 Response finishResponse = bdio2RetryAwareStreamUploader.finish(uploadUrl, count, editor);
                 bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(finishResponse);
             }
-        } catch (RetriableBdioUploadException e) {
+        } catch (RetriableBdioUploadException | InterruptedException e) {
             complete = false;
         }
     }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceBatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceBatchRunner.java
@@ -31,19 +31,19 @@ public class IntelligentPersistenceBatchRunner {
         this.bdio2FileUploadService = bdio2FileUploadService;
     }
 
-    public UploadBatchOutput executeUploads(UploadBatch uploadBatch, long timeout) throws BlackDuckIntegrationException {
+    public UploadBatchOutput executeUploads(UploadBatch uploadBatch, long timeout, long clientStartTime) throws BlackDuckIntegrationException {
         logger.info("Starting the codelocation file uploads.");
-        UploadBatchOutput uploadBatchOutput = uploadTargets(uploadBatch, timeout);
+        UploadBatchOutput uploadBatchOutput = uploadTargets(uploadBatch, timeout, clientStartTime);
         logger.info("Completed the codelocation file uploads.");
 
         return uploadBatchOutput;
     }
 
-    private UploadBatchOutput uploadTargets(UploadBatch uploadBatch, long timeout) throws BlackDuckIntegrationException {
+    private UploadBatchOutput uploadTargets(UploadBatch uploadBatch, long timeout, long clientStartTime) throws BlackDuckIntegrationException {
         List<UploadOutput> uploadOutputs = new ArrayList<>();
 
         try {
-            List<IntelligentPersistenceCallable> callables = createCallables(uploadBatch, timeout);
+            List<IntelligentPersistenceCallable> callables = createCallables(uploadBatch, timeout, clientStartTime);
             List<Future<UploadOutput>> submitted = new ArrayList<>();
             for (IntelligentPersistenceCallable callable : callables) {
                 submitted.add(executorService.submit(callable));
@@ -59,10 +59,10 @@ public class IntelligentPersistenceBatchRunner {
         return new UploadBatchOutput(uploadOutputs);
     }
 
-    private List<IntelligentPersistenceCallable> createCallables(UploadBatch uploadBatch, long timeout) {
+    private List<IntelligentPersistenceCallable> createCallables(UploadBatch uploadBatch, long timeout, long clientStartTime) {
         List<IntelligentPersistenceCallable> callables = uploadBatch.getUploadTargets()
                                                              .stream()
-                                                             .map(uploadTarget -> new IntelligentPersistenceCallable(bdio2FileUploadService, uploadTarget, timeout))
+                                                             .map(uploadTarget -> new IntelligentPersistenceCallable(bdio2FileUploadService, uploadTarget, timeout, clientStartTime))
                                                              .collect(Collectors.toList());
 
         return callables;

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCallable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCallable.java
@@ -21,11 +21,13 @@ public class IntelligentPersistenceCallable implements Callable<UploadOutput> {
     private final Bdio2FileUploadService bdio2FileUploadService;
     private final UploadTarget uploadTarget;
     private final long timeout;
+    private final long clientStartTime;
 
-    public IntelligentPersistenceCallable(Bdio2FileUploadService bdio2FileUploadService, UploadTarget uploadTarget, long timeout) {
+    public IntelligentPersistenceCallable(Bdio2FileUploadService bdio2FileUploadService, UploadTarget uploadTarget, long timeout, long clientStartTime) {
         this.bdio2FileUploadService = bdio2FileUploadService;
         this.uploadTarget = uploadTarget;
         this.timeout = timeout;
+        this.clientStartTime = clientStartTime;
     }
 
     @Override
@@ -34,7 +36,7 @@ public class IntelligentPersistenceCallable implements Callable<UploadOutput> {
         NameVersion projectAndVersion = uploadTarget.getProjectAndVersion().orElse(null);
         String codeLocationName = uploadTarget.getCodeLocationName();
         try {
-            Bdio2UploadResult result = bdio2FileUploadService.uploadFile(uploadTarget, timeout);
+            Bdio2UploadResult result = bdio2FileUploadService.uploadFile(uploadTarget, timeout, clientStartTime);
             return UploadOutput.SUCCESS(projectAndVersion, codeLocationName, null, result.getScanId());
         } catch (Exception ex) {
             String errorMessage = String.format("Failed to upload file: %s because %s", uploadTarget.getUploadFile().getAbsolutePath(), ex.getMessage());

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCodeLocationCreationRequest.java
@@ -16,15 +16,17 @@ public class IntelligentPersistenceCodeLocationCreationRequest extends CodeLocat
     private final IntelligentPersistenceBatchRunner uploadBatchRunner;
     private final UploadBatch uploadBatch;
     private final long timeout;
+    private final long clientStartTime;
 
-    public IntelligentPersistenceCodeLocationCreationRequest(final IntelligentPersistenceBatchRunner uploadBatchRunner, final UploadBatch uploadBatch, final long timeout) {
+    public IntelligentPersistenceCodeLocationCreationRequest(final IntelligentPersistenceBatchRunner uploadBatchRunner, final UploadBatch uploadBatch, final long timeout, final long clientStartTime) {
         this.uploadBatchRunner = uploadBatchRunner;
         this.uploadBatch = uploadBatch;
         this.timeout = timeout;
+        this.clientStartTime = clientStartTime;
     }
 
     @Override
     public UploadBatchOutput executeRequest() throws BlackDuckIntegrationException {
-        return uploadBatchRunner.executeUploads(uploadBatch, timeout);
+        return uploadBatchRunner.executeUploads(uploadBatch, timeout, clientStartTime);
     }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
@@ -33,16 +33,16 @@ public class IntelligentPersistenceService extends DataService {
         this.codeLocationCreationService = codeLocationCreationService;
     }
 
-    public IntelligentPersistenceCodeLocationCreationRequest createUploadRequest(UploadBatch uploadBatch, long timeoutInSeconds) {
-        return new IntelligentPersistenceCodeLocationCreationRequest(uploadBatchRunner, uploadBatch, timeoutInSeconds);
+    public IntelligentPersistenceCodeLocationCreationRequest createUploadRequest(UploadBatch uploadBatch, long timeoutInSeconds, long clientStartTime) {
+        return new IntelligentPersistenceCodeLocationCreationRequest(uploadBatchRunner, uploadBatch, timeoutInSeconds, clientStartTime);
     }
 
     public CodeLocationCreationData<UploadBatchOutput> uploadBdio(CodeLocationCreationRequest<UploadBatchOutput> uploadRequest) throws IntegrationException {
         return codeLocationCreationService.createCodeLocations(uploadRequest);
     }
 
-    public CodeLocationCreationData<UploadBatchOutput> uploadBdio(UploadBatch uploadBatch, long timeoutInSeconds) throws IntegrationException {
-        IntelligentPersistenceCodeLocationCreationRequest uploadRequest = createUploadRequest(uploadBatch, timeoutInSeconds);
+    public CodeLocationCreationData<UploadBatchOutput> uploadBdio(UploadBatch uploadBatch, long timeoutInSeconds, long clientStartTime) throws IntegrationException {
+        IntelligentPersistenceCodeLocationCreationRequest uploadRequest = createUploadRequest(uploadBatch, timeoutInSeconds, clientStartTime);
         return uploadBdio(uploadRequest);
     }
 
@@ -50,8 +50,8 @@ public class IntelligentPersistenceService extends DataService {
         return codeLocationCreationService.createCodeLocationsAndWait(uploadRequest, timeoutInSeconds);
     }
 
-    public UploadBatchOutput uploadBdioAndWait(UploadBatch uploadBatch, long timeoutInSeconds) throws IntegrationException, InterruptedException {
-        IntelligentPersistenceCodeLocationCreationRequest uploadRequest = createUploadRequest(uploadBatch, (int) timeoutInSeconds);
+    public UploadBatchOutput uploadBdioAndWait(UploadBatch uploadBatch, long timeoutInSeconds, long clientStartTime) throws IntegrationException, InterruptedException {
+        IntelligentPersistenceCodeLocationCreationRequest uploadRequest = createUploadRequest(uploadBatch, (int) timeoutInSeconds, clientStartTime);
         return uploadBdioAndWait(uploadRequest, timeoutInSeconds);
     }
 

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -28,7 +28,7 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
     
     @Test
-    void testStartRetrableWithRetryAfterHeader() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
+    void testStartRetryableWithRetryAfterHeader() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -15,12 +15,12 @@ import com.synopsys.integration.rest.response.Response;
 class Bdio2RetryAwareStreamUploaderTest {
 
     @Test
-    void testStartRetriable() throws IntegrationException {
+    void testStartRetriable() throws IntegrationException, InterruptedException {
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrows512OnStart(editor, bdioFileContent);
         try {
-            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
+            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor, System.currentTimeMillis(), System.currentTimeMillis() + 10000);
             Assertions.fail("Expected RetriableBdioUploadException");
         } catch (RetriableBdioUploadException e) {
             // expected
@@ -56,12 +56,12 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @Test
-    void testStartNonRetriable() throws IntegrationException, RetriableBdioUploadException {
+    void testStartNonRetriable() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         BdioFileContent bdioFileContent = Mockito.mock(BdioFileContent.class);
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderThrow404OnStart(bdioFileContent, editor);
         try {
-            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor);
+            bdio2RetryAwareStreamUploader.start(bdioFileContent, editor, System.currentTimeMillis(), System.currentTimeMillis() + 10000);
             Assertions.fail("Expected RetriableBdioUploadException");
         } catch (IntegrationException e) {
             // expected
@@ -75,7 +75,7 @@ class Bdio2RetryAwareStreamUploaderTest {
         Mockito.when(response400.isStatusCodeSuccess()).thenReturn(false);
         Mockito.when(response400.getStatusCode()).thenReturn(400);
         try {
-            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response400, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
+            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response400);
             Assertions.fail("Expected RetriableBdioUploadException");
         } catch (RetriableBdioUploadException e) {
             // expected
@@ -88,7 +88,7 @@ class Bdio2RetryAwareStreamUploaderTest {
         Response response200 = Mockito.mock(Response.class);
         Mockito.when(response200.isStatusCodeSuccess()).thenReturn(true);
         Mockito.when(response200.getStatusCode()).thenReturn(200);
-        bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response200, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
+        bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response200);
     }
 
     @Test
@@ -98,7 +98,7 @@ class Bdio2RetryAwareStreamUploaderTest {
         Mockito.when(response404.isStatusCodeSuccess()).thenReturn(false);
         Mockito.when(response404.getStatusCode()).thenReturn(404);
         try {
-            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response404, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
+            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response404);
             Assertions.fail("Expected IntegrationException");
         } catch (IntegrationException e) {
             // expected

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploaderTest.java
@@ -69,13 +69,13 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @Test
-    void testNoExceptionStatusCodeAnalysisRetryable() throws IntegrationException {
+    void testNoExceptionStatusCodeAnalysisRetryable() throws IntegrationException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderMinimal();
         Response response400 = Mockito.mock(Response.class);
         Mockito.when(response400.isStatusCodeSuccess()).thenReturn(false);
         Mockito.when(response400.getStatusCode()).thenReturn(400);
         try {
-            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response400);
+            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response400, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
             Assertions.fail("Expected RetriableBdioUploadException");
         } catch (RetriableBdioUploadException e) {
             // expected
@@ -83,22 +83,22 @@ class Bdio2RetryAwareStreamUploaderTest {
     }
 
     @Test
-    void testNoExceptionStatusCodeAnalysisSuccess() throws IntegrationException, RetriableBdioUploadException {
+    void testNoExceptionStatusCodeAnalysisSuccess() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderMinimal();
         Response response200 = Mockito.mock(Response.class);
         Mockito.when(response200.isStatusCodeSuccess()).thenReturn(true);
         Mockito.when(response200.getStatusCode()).thenReturn(200);
-        bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response200);
+        bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response200, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
     }
 
     @Test
-    void testNoExceptionStatusCodeAnalysisNonRetryable() throws IntegrationException, RetriableBdioUploadException {
+    void testNoExceptionStatusCodeAnalysisNonRetryable() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2RetryAwareStreamUploader = mockBdio2RetryAwareStreamUploaderMinimal();
         Response response404 = Mockito.mock(Response.class);
         Mockito.when(response404.isStatusCodeSuccess()).thenReturn(false);
         Mockito.when(response404.getStatusCode()).thenReturn(404);
         try {
-            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response404);
+            bdio2RetryAwareStreamUploader.onErrorThrowRetryableOrFailure(response404, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
             Assertions.fail("Expected IntegrationException");
         } catch (IntegrationException e) {
             // expected

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -30,7 +30,7 @@ public class Bdio2UploadJobTest {
     private final int waitInterval = 2;
 
     @Test
-    public void testRetryOnFailedHeaderUpload() throws IntegrationException, RetriableBdioUploadException {
+    public void testRetryOnFailedHeaderUpload() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnStart();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
@@ -38,7 +38,7 @@ public class Bdio2UploadJobTest {
     }
 
     @Test
-    public void testRetryOnFailedChunkUpload() throws IntegrationException, RetriableBdioUploadException {
+    public void testRetryOnFailedChunkUpload() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnAppend();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
@@ -46,35 +46,35 @@ public class Bdio2UploadJobTest {
     }
 
     @Test
-    public void testRetryOnFailedFinish() throws IntegrationException, RetriableBdioUploadException {
+    public void testRetryOnFailedFinish() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = getUploaderThatThrowsRetriableOnFinish();
         Bdio2UploadJob bdio2UploadJob = getUploadJob(bdio2StreamUploader);
         ResilientJobExecutor jobExecutor = getJobExecutor();
         Assertions.assertThrows(IntegrationTimeoutException.class, () -> jobExecutor.executeJob(bdio2UploadJob));
     }
 
-    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnStart() throws IntegrationException, RetriableBdioUploadException {
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnStart() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
-        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenThrow(new RetriableBdioUploadException());
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.anyLong())).thenThrow(new RetriableBdioUploadException());
         return bdio2StreamUploader;
     }
 
-    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnAppend() throws IntegrationException, RetriableBdioUploadException {
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnAppend() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
         Response successResponse = Mockito.mock(Response.class);
         Mockito.when(successResponse.isStatusCodeSuccess()).thenReturn(true);
         Mockito.when(successResponse.getHeaderValue("location")).thenReturn("https://server.blackduck.com/api/endpoint/scanId");
-        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successResponse);
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.anyLong())).thenReturn(successResponse);
         Mockito.when(bdio2StreamUploader.append(Mockito.any(HttpUrl.class), Mockito.anyInt(), Mockito.any(BdioFileContent.class), Mockito.any(BlackDuckRequestBuilderEditor.class))).thenThrow(new RetriableBdioUploadException());
         return bdio2StreamUploader;
     }
 
-    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnFinish() throws IntegrationException, RetriableBdioUploadException {
+    private Bdio2RetryAwareStreamUploader getUploaderThatThrowsRetriableOnFinish() throws IntegrationException, RetriableBdioUploadException, InterruptedException {
         Bdio2RetryAwareStreamUploader bdio2StreamUploader = Mockito.mock(Bdio2RetryAwareStreamUploader.class);
         Response successResponse = Mockito.mock(Response.class);
         Mockito.when(successResponse.isStatusCodeSuccess()).thenReturn(true);
         Mockito.when(successResponse.getHeaderValue("location")).thenReturn("https://server.blackduck.com/api/endpoint/scanId");
-        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any())).thenReturn(successResponse);
+        Mockito.when(bdio2StreamUploader.start(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.anyLong())).thenReturn(successResponse);
         Mockito.when(bdio2StreamUploader.append(Mockito.any(HttpUrl.class), Mockito.anyInt(), Mockito.any(BdioFileContent.class), Mockito.any(BlackDuckRequestBuilderEditor.class))).thenReturn(successResponse);
         Mockito.when(bdio2StreamUploader.finish(Mockito.any(), Mockito.anyInt(), Mockito.any())).thenThrow(new RetriableBdioUploadException());
         return bdio2StreamUploader;

--- a/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJobTest.java
@@ -91,6 +91,6 @@ public class Bdio2UploadJobTest {
         BdioFileContent header = new BdioFileContent("bdio-header.jsonld", "");
         BdioFileContent entry = new BdioFileContent("bdio-entry-00.jsonld", "");
         BlackDuckRequestBuilderEditor editor = Mockito.mock(BlackDuckRequestBuilderEditor.class);
-        return new Bdio2UploadJob(bdio2StreamUploader, header, Collections.singletonList(entry), editor, 2, true, true);
+        return new Bdio2UploadJob(bdio2StreamUploader, header, Collections.singletonList(entry), editor, 2, true, true, System.currentTimeMillis(), System.currentTimeMillis() * 1000);
     }
 }

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/recipe/IntelligentPersistenceRecipeTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/recipe/IntelligentPersistenceRecipeTest.java
@@ -83,7 +83,7 @@ class IntelligentPersistenceRecipeTest extends BasicRecipe {
 
         // now all the setup is done, we can upload the bdio2 file
         IntelligentPersistenceService intelligentPersistenceService = blackDuckServicesFactory.createIntelligentPersistenceService();
-        UploadBatchOutput uploadBatchOutput = intelligentPersistenceService.uploadBdioAndWait(uploadBatch, 120);
+        UploadBatchOutput uploadBatchOutput = intelligentPersistenceService.uploadBdioAndWait(uploadBatch, 120, 0);
         assertFalse(uploadBatchOutput.hasAnyFailures());
 
         // verify that we now have a bom with 1 component


### PR DESCRIPTION
When BlackDuck returns a 429 we should look for the retry-after header and wait that number of seconds before resubmitting the scan.