### PR TITLE
update blackduck-common-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.synopsys.integration:blackduck-common-api:2023.4.2.2'
+    api 'com.synopsys.integration:blackduck-common-api:2023.10.0.1'
     api 'com.synopsys.integration:phone-home-client:5.1.10'
     api 'com.synopsys.integration:integration-bdio:26.0.9'
     api 'com.blackducksoftware.bdio:bdio2:3.2.5'


### PR DESCRIPTION
Brings in the 2023.10 generation to make use of the new category endpoint among other things.