### PR TITLE
revert to 2023.4.2.2 api and enhance retry error message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.synopsys.integration:blackduck-common-api:2023.10.0.1'
+    api 'com.synopsys.integration:blackduck-common-api:2023.4.2.2'
     api 'com.synopsys.integration:phone-home-client:5.1.10'
     api 'com.synopsys.integration:integration-bdio:26.0.9'
     api 'com.blackducksoftware.bdio:bdio2:3.2.5'

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -46,7 +46,7 @@ public class Bdio2RetryAwareStreamUploader {
                     if (isClientTimeoutExceededBy(clientStartTime, retryAfterInMillis, clientTimeout)) {
                         throw new BlackDuckIntegrationException("Client timeout exceeded or will be exceeded due to server being busy.");
                     }
-                    logger.trace("Waiting " + retryAfterInMillis + " milliseconds to retry BDIO upload start operation.");
+                    logger.debug("Received code {}. Waiting {} milliseconds to retry BDIO upload start operation.", response.getStatusCode(), retryAfterInMillis);
                     Thread.sleep(retryAfterInMillis);
                     return start(header, editor, clientStartTime, clientTimeout);
                 }


### PR DESCRIPTION
This does some improvements to blackduck-common to make it work with more BlackDuck server

1) It rolls back to the 2023.4.2.2 generation as that works with all supported servers for most use cases. The 2023.10 generation was breaking with earlier versions of BlackDuck

2) It updates a retry message to make it more easy to understand why it is retrying. It also shows the message at the debug level which is more consistent with other messages of this type.