### PR TITLE
Remove Full Snippet Matching Options from Signature Scan

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
@@ -20,7 +20,6 @@ public class BlackDuckOnlineProperties {
 
     private final boolean snippetMatchingFlag;
     private final boolean snippetMatchingOnlyFlag;
-    private final boolean fullSnippetScanFlag;
 
     public BlackDuckOnlineProperties(SnippetMatching snippetMatchingMode, boolean uploadSource, boolean licenseSearch, boolean copyrightSearch) {
         this.snippetMatchingMode = snippetMatchingMode;
@@ -28,9 +27,8 @@ public class BlackDuckOnlineProperties {
         this.licenseSearch = licenseSearch;
         this.copyrightSearch = copyrightSearch;
 
-        snippetMatchingFlag = SnippetMatching.SNIPPET_MATCHING == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING == snippetMatchingMode;
-        snippetMatchingOnlyFlag = SnippetMatching.SNIPPET_MATCHING_ONLY == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING_ONLY == snippetMatchingMode;
-        fullSnippetScanFlag = SnippetMatching.FULL_SNIPPET_MATCHING == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING_ONLY == snippetMatchingMode;
+        snippetMatchingFlag = SnippetMatching.SNIPPET_MATCHING == snippetMatchingMode;
+        snippetMatchingOnlyFlag = SnippetMatching.SNIPPET_MATCHING_ONLY == snippetMatchingMode;
     }
 
     public boolean isOnlineCapabilityNeeded() {
@@ -43,10 +41,6 @@ public class BlackDuckOnlineProperties {
                 cmd.add("--snippet-matching");
             } else {
                 cmd.add("--snippet-matching-only");
-            }
-
-            if (fullSnippetScanFlag) {
-                cmd.add("--full-snippet-scan");
             }
         }
 
@@ -79,10 +73,6 @@ public class BlackDuckOnlineProperties {
 
     public boolean isSnippetMatchingOnly() {
         return snippetMatchingOnlyFlag;
-    }
-
-    public boolean isFullSnippetScan() {
-        return fullSnippetScanFlag;
     }
 
     public boolean isUploadSource() {

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -336,10 +336,6 @@ public class ScanCommand {
         return blackDuckOnlineProperties.isSnippetMatchingOnly();
     }
 
-    public boolean isFullSnippetScan() {
-        return blackDuckOnlineProperties.isFullSnippetScan();
-    }
-
     public boolean isUploadSource() {
         return blackDuckOnlineProperties.isUploadSource();
     }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
@@ -9,8 +9,6 @@ package com.synopsys.integration.blackduck.codelocation.signaturescanner.command
 
 public enum SnippetMatching {
     SNIPPET_MATCHING,
-    SNIPPET_MATCHING_ONLY,
-    FULL_SNIPPET_MATCHING,
-    FULL_SNIPPET_MATCHING_ONLY
+    SNIPPET_MATCHING_ONLY
 
 }

--- a/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilderTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilderTest.java
@@ -80,14 +80,6 @@ public class ScanBatchBuilderTest {
         assertTrue(builder.isValid());
     }
 
-    @Test
-    public void testUploadSourceWithSnippetMatching() {
-        ScanBatchBuilder builder = createInitialValidBuilder();
-        builder.uploadSource(true);
-        builder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY);
-        assertTrue(builder.isValid());
-    }
-
     private ScanBatchBuilder createInitialValidBuilder() {
         ScanBatchBuilder builder = new ScanBatchBuilder();
         try {

--- a/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
@@ -71,53 +71,6 @@ public class ScanCommandTest {
     }
 
     @Test
-    public void testFullSnippetScan() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, true, false, true);
-    }
-
-    @Test
-    public void testFullSnippetOnlyScan() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
-    }
-
-    @Test
-    public void testSnippetScanWithUploadSource() throws IntegrationException {
-        scanBatchBuilder.uploadSource(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY, true);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
-        assertUploadSource(commandList, true);
-    }
-
-    @Test
-    public void testSnippetScanWithoutUploadSource() throws IntegrationException {
-        scanBatchBuilder.uploadSource(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY, false);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
-        assertUploadSource(commandList, false);
-    }
-
-    @Test
-    public void testSnippetScanLoggingWhenDryRun() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING);
-
-        ScanBatch scanBatch = scanBatchBuilder.build();
-        ScanCommand scanCommand = assertCommand(scanBatch);
-
-        assertLogging(scanCommand, 0);
-        BufferedIntLogger bufferedLogger;
-
-        scanBatchBuilder.dryRun(true);
-        scanBatch = scanBatchBuilder.build();
-        scanCommand = assertCommand(scanBatch);
-
-        assertLogging(scanCommand, 1);
-    }
-
-    @Test
     public void testWithoutLicenseSearch() throws IntegrationException {
         scanBatchBuilder.licenseSearch(false);
         List<String> commandList = createCommandList();


### PR DESCRIPTION
As per the request in the ticket: IDETECT-4176, the FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options will be removed from Scan CLI as it uses registration key which will not be granted for customer use in the future. Therefore, this ticket removes this options from the [detect.blackduck.signature.scanner.snippet.matching](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/properties/configuration/signature-scanner.html#snippet-matching) property in detect.