### PR TITLE
Treat key-value pairs in scan command additional arguments as overrides

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleComponentUsageValueSetType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleComponentUsageValueSetType.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleConditionOperatorType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleConditionOperatorType.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleConditionType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/enumeration/PolicyRuleConditionType.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/api/enumeration/RankedSeverityType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/enumeration/RankedSeverityType.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/api/enumeration/ReviewStatusType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/enumeration/ReviewStatusType.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2FileUploadService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2StreamUploader.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadJob.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadResult.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2UploadResult.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/RetriableBdioUploadException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/RetriableBdioUploadException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/model/Bdio2Document.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/model/Bdio2Document.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/model/BdioFileContent.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/model/BdioFileContent.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/model/GitInfo.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/model/GitInfo.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/model/ProjectInfo.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/model/ProjectInfo.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2ContentExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2ContentExtractor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Factory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Factory.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Writer.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/util/Bdio2Writer.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationBatchOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationBatchOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationData.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationData.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationCreationService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitJob.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitJob.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitJobCondition.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitJobCondition.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitResult.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaitResult.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaiter.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationWaiter.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationsRetriever.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/CodeLocationsRetriever.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/Result.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/Result.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/Bdio2UploadCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/Bdio2UploadCodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/Bdio2UploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/Bdio2UploadService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/UploadBdio2BatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/UploadBdio2BatchRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/UploadBdio2Callable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdio2legacy/UploadBdio2Callable.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/BdioUploadCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/BdioUploadCodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/BdioUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/BdioUploadService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/UploadBatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/UploadBatchRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/UploadCallable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/bdiolegacy/UploadCallable.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScan.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScan.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatch.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatchOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatchOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanBatchRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanCallable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanCallable.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanCodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceBatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceBatchRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCallable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCallable.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceCodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/SignatureScannerCodeLocationCreationRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/SignatureScannerCodeLocationCreationRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/SignatureScannerService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/SignatureScannerService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ExistingScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ExistingScannerInstaller.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/IndividualFileMatching.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/IndividualFileMatching.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ReducedPersistence.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ReducedPersistence.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -174,8 +174,8 @@ public class ScanCommand {
         }
         List<Integer> indecesList = commandKeysToKeyRelatedIndices.get(key);
 
-        indecesList.add(command.size());
-        indecesList.add(command.size() + 1);
+        indecesList.add(command.size());     // track the index of the key
+        indecesList.add(command.size() + 1); // track the index of the value
 
         appendSingleArgument(key);
         appendSingleArgument(value);

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -11,6 +11,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -52,6 +55,10 @@ public class ScanCommand {
     private final String correlationId;
     private final String bomCompareMode;
 
+    private List<String> command;
+
+    private Map<String, List<Integer>> commandKeysToKeyRelatedIndeces;
+
     public ScanCommand(File signatureScannerInstallDirectory, File outputDirectory, boolean dryRun, ProxyInfo proxyInfo, String scanCliOpts, int scanMemoryInMegabytes, String scheme, String host, String blackDuckApiToken,
         String blackDuckUsername, String blackDuckPassword, int port, boolean runInsecure, String name, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, Set<String> excludePatterns,
         String additionalScanArguments, String targetPath, boolean verbose, boolean debug, String projectName, String versionName, boolean isRapid,
@@ -87,166 +94,190 @@ public class ScanCommand {
     }
 
     public List<String> createCommandForProcessBuilder(IntLogger logger, ScanPaths scannerPaths, String specificRunOutputDirectoryPath) throws IllegalArgumentException, IntegrationException {
-        List<String> cmd = new ArrayList<>();
+        command = new ArrayList<>();
+        commandKeysToKeyRelatedIndeces = new HashMap<>();
+
         logger.debug("Using this java installation : " + scannerPaths.getPathToJavaExecutable());
 
-        scannerPaths.addJavaAndOnePathArguments(cmd);
+        scannerPaths.addJavaAndOnePathArguments(command);
 
         if (proxyInfo.shouldUseProxy()) {
-            populateProxyDetails(cmd);
+            populateProxyDetails();
         }
 
-        populateScanCliOpts(cmd);
+        populateScanCliOpts();
 
-        cmd.add("-Xmx" + scanMemoryInMegabytes + "m");
-        scannerPaths.addScanExecutableArguments(cmd);
+        appendSingleArgument("-Xmx" + scanMemoryInMegabytes + "m");
+        scannerPaths.addScanExecutableArguments(command);
 
-        cmd.add("--no-prompt");
+        appendSingleArgument("--no-prompt");
 
         if (!dryRun) {
-            populateOnlineProperties(logger, cmd);
+            populateOnlineProperties(logger);
         } else {
-            populateOfflineProperties(logger, specificRunOutputDirectoryPath, cmd);
+            populateOfflineProperties(logger, specificRunOutputDirectoryPath);
         }
 
         if (verbose) {
-            cmd.add("-v");
+            appendSingleArgument("-v");
         }
         if (debug) {
-            cmd.add("--debug");
+            appendSingleArgument("--debug");
         }
 
-        cmd.add("--logDir");
-        cmd.add(specificRunOutputDirectoryPath);
+        appendKeyValuePair("--logDir", specificRunOutputDirectoryPath);
 
         // Only add the statusWriteDir option if Black Duck supports the statusWriteDir option
         // The scanStatusDirectoryPath is the same as the log directory path
         // The CLI will create a subdirectory for the status files
-        cmd.add("--statusWriteDir");
-        cmd.add(specificRunOutputDirectoryPath);
+        appendKeyValuePair("--statusWriteDir", specificRunOutputDirectoryPath);
 
-        populateProjectAndVersion(cmd);
+        populateProjectAndVersion();
 
         if (StringUtils.isNotBlank(name)) {
-            cmd.add("--name");
-            cmd.add(name);
+            appendKeyValuePair("--name", name);
         }
 
-        populateExcludePatterns(cmd);
+        populateExcludePatterns();
 
         if (null != individualFileMatching) {
-            cmd.add("--individualFileMatching=" + individualFileMatching);
+            appendKeyValuePair("--individualFileMatching", individualFileMatching.toString());
         }
 
         if (isRapid) {
-            cmd.add("--no-persistence");
+            appendSingleArgument("--no-persistence");
             
             // --no-persistence-mode should never be used without --no-persistence so
             // only set it in this block.
-            cmd.add("--no-persistence-mode=" + bomCompareMode);
+            appendKeyValuePair("--no-persistence-mode", bomCompareMode);
         }
 
-        populateReducedPersistence(cmd);
+        populateReducedPersistence();
 
         if (StringUtils.isNotBlank(correlationId)) {
-            cmd.add("--correlationId");
-            cmd.add(correlationId);
+            appendKeyValuePair("--correlationId", correlationId);
         }
 
         ScanCommandArgumentParser parser = new ScanCommandArgumentParser();
-        populateAdditionalScanArguments(cmd, parser);
+        populateAdditionalScanArgumentsAndRemoveOverridden(parser);
 
-        return cmd;
+        return command;
     }
 
-    private void populateReducedPersistence(List<String> cmd) {
+    private void appendSingleArgument(String arg) {
+        command.add(arg);
+    }
+
+    private void appendKeyValuePair(String key, String value) {
+        if (!commandKeysToKeyRelatedIndeces.containsKey(key)) {
+            commandKeysToKeyRelatedIndeces.put(key, new ArrayList<>());
+        }
+        List<Integer> indecesList = commandKeysToKeyRelatedIndeces.get(key);
+
+        indecesList.add(command.size());
+        indecesList.add(command.size() + 1);
+
+        appendSingleArgument(key);
+        appendSingleArgument(value);
+    }
+
+    private void populateReducedPersistence() {
         if (reducedPersistence != null) {
             if (reducedPersistence.equals(ReducedPersistence.DISCARD_UNMATCHED)) {
-                cmd.add("--discard-unmatched-files");
+                appendSingleArgument("--discard-unmatched-files");
             }
             if (reducedPersistence.equals(ReducedPersistence.RETAIN_UNMATCHED)) {
-                cmd.add("--retain-unmatched-files");
+                appendSingleArgument("--retain-unmatched-files");
             }
         }
     }
 
-    private void populateAdditionalScanArguments(List<String> cmd, ScanCommandArgumentParser parser) throws IntegrationException {
+    private void populateAdditionalScanArgumentsAndRemoveOverridden(ScanCommandArgumentParser parser) throws IntegrationException {
+        Set<Integer> overriddenArgIndexes = new HashSet<>();
+
         List<String> arguments = parser.parse(additionalScanArguments);
+
         for (String argument : arguments) {
             if (StringUtils.isNotBlank(argument)) {
-                cmd.add(argument);
+                if (commandKeysToKeyRelatedIndeces.containsKey(argument)) {
+                    overriddenArgIndexes.addAll(commandKeysToKeyRelatedIndeces.get(argument));
+                }
+                appendSingleArgument(argument);
             }
+        }
+
+        if (overriddenArgIndexes.size() > 0) {
+            List<String> updatedCommand = new ArrayList<>();
+            for (int i = 0; i < command.size(); i++) {
+                if (!overriddenArgIndexes.contains(i)) {
+                    updatedCommand.add(command.get(i));
+                }
+            }
+            command = updatedCommand;
         }
     }
 
-    private void populateExcludePatterns(List<String> cmd) {
+    private void populateExcludePatterns() {
         if (excludePatterns != null) {
             for (String exclusionPattern : excludePatterns) {
                 if (StringUtils.isNotBlank(exclusionPattern)) {
-                    cmd.add("--exclude");
-                    cmd.add(exclusionPattern);
+                    appendKeyValuePair("--exclude", exclusionPattern);
                 }
             }
         }
     }
 
-    private void populateProjectAndVersion(List<String> cmd) {
+    private void populateProjectAndVersion() {
         if (StringUtils.isNotBlank(projectName) && StringUtils.isNotBlank(versionName)) {
-            cmd.add("--project");
-            cmd.add(projectName);
-            cmd.add("--release");
-            cmd.add(versionName);
+            appendKeyValuePair("--project", projectName);
+            appendKeyValuePair("--release", versionName);
         }
     }
 
-    private void populateOfflineProperties(IntLogger logger, String specificRunOutputDirectoryPath, List<String> cmd) {
+    private void populateOfflineProperties(IntLogger logger, String specificRunOutputDirectoryPath) {
         logger.info("You have configured this signature scan to run in dry run mode - no results will be submitted to Black Duck.");
         blackDuckOnlineProperties.warnIfOnlineIsNeeded(logger::warn);
 
         // The dryRunWriteDir is the same as the log directory path
         // The CLI will create a subdirectory for the json files
-        cmd.add("--dryRunWriteDir");
-        cmd.add(specificRunOutputDirectoryPath);
+        appendKeyValuePair("--dryRunWriteDir", specificRunOutputDirectoryPath);
     }
 
-    private void populateOnlineProperties(IntLogger logger, List<String> cmd) {
-        cmd.add("--scheme");
-        cmd.add(scheme);
-        cmd.add("--host");
-        cmd.add(host);
+    private void populateOnlineProperties(IntLogger logger) {
+        appendKeyValuePair("--scheme", scheme);
+        appendKeyValuePair("--host", host);
+
         logger.debug("Using the Black Duck hostname : '" + host + "'");
 
         if (StringUtils.isEmpty(blackDuckApiToken)) {
-            cmd.add("--username");
-            cmd.add(blackDuckUsername);
+            appendKeyValuePair("--username", blackDuckUsername);
         }
 
         int blackDuckPort = port;
         if (blackDuckPort > 0) {
-            cmd.add("--port");
-            cmd.add(Integer.toString(blackDuckPort));
+            appendKeyValuePair("--port", Integer.toString(blackDuckPort));
         } else {
             logger.warn("Could not find a port to use for the Server.");
         }
 
         if (runInsecure) {
-            cmd.add("--insecure");
+            appendSingleArgument("--insecure");
         }
 
-        blackDuckOnlineProperties.addOnlineCommands(cmd);
+        blackDuckOnlineProperties.addOnlineCommands(command);
     }
 
-    private void populateScanCliOpts(List<String> cmd) {
+    private void populateScanCliOpts() {
         if (StringUtils.isNotBlank(scanCliOpts)) {
             for (String scanOpt : scanCliOpts.split(" ")) {
                 if (StringUtils.isNotBlank(scanOpt)) {
-                    cmd.add(scanOpt);
+                    appendSingleArgument(scanOpt);
                 }
             }
         }
     }
 
-    private void populateProxyDetails(List<String> cmd) {
+    private void populateProxyDetails() {
         ProxyInfo blackDuckProxyInfo = proxyInfo;
         String proxyHost = blackDuckProxyInfo.getHost().orElse(null);
         int proxyPort = blackDuckProxyInfo.getPort();
@@ -254,21 +285,34 @@ public class ScanCommand {
         String proxyPassword = blackDuckProxyInfo.getPassword().orElse(null);
         String proxyNtlmDomain = blackDuckProxyInfo.getNtlmDomain().orElse(null);
         String proxyNtlmWorkstation = blackDuckProxyInfo.getNtlmWorkstation().orElse(null);
-        cmd.add("-Dhttp.proxyHost=" + proxyHost);
-        cmd.add("-Dhttp.proxyPort=" + proxyPort);
+
+        appendSingleArgument("-Dhttp.proxyHost");
+        appendSingleArgument(proxyHost);
+
+        appendSingleArgument("-Dhttp.proxyPort");
+        appendSingleArgument(Integer.toString(proxyPort));
+
         if (StringUtils.isNotBlank(proxyUsername) && StringUtils.isNotBlank(proxyPassword)) {
-            cmd.add("-Dhttp.proxyUser=" + proxyUsername);
-            cmd.add("-Dhttp.proxyPassword=" + proxyPassword);
+            appendSingleArgument("-Dhttp.proxyUser");
+            appendSingleArgument(proxyUsername);
+
+            appendSingleArgument("-Dhttp.proxyPassword");
+            appendSingleArgument(proxyPassword);
         } else {
             // CLI will ignore the proxy host and port if there are no credentials
-            cmd.add("-Dhttp.proxyUser=user");
-            cmd.add("-Dhttp.proxyPassword=password");
+            appendSingleArgument("-Dhttp.proxyUser");
+            appendSingleArgument("user");
+
+            appendSingleArgument("-Dhttp.proxyPassword");
+            appendSingleArgument("password");
         }
         if (StringUtils.isNotBlank(proxyNtlmDomain)) {
-            cmd.add("-Dhttp.auth.ntlm.domain=" + proxyNtlmDomain);
+            appendSingleArgument("-Dhttp.auth.ntlm.domain");
+            appendSingleArgument(proxyNtlmDomain);
         }
         if (StringUtils.isNotBlank(proxyNtlmWorkstation)) {
-            cmd.add("-Dblackduck.http.auth.ntlm.workstation=" + proxyNtlmWorkstation);
+            appendSingleArgument("-Dblackduck.http.auth.ntlm.workstation");
+            appendSingleArgument(proxyNtlmWorkstation);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -57,7 +57,7 @@ public class ScanCommand {
 
     private List<String> command;
 
-    private Map<String, List<Integer>> commandKeysToKeyRelatedIndeces;
+    private Map<String, List<Integer>> commandKeysToKeyRelatedIndices;
 
     public ScanCommand(File signatureScannerInstallDirectory, File outputDirectory, boolean dryRun, ProxyInfo proxyInfo, String scanCliOpts, int scanMemoryInMegabytes, String scheme, String host, String blackDuckApiToken,
         String blackDuckUsername, String blackDuckPassword, int port, boolean runInsecure, String name, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, Set<String> excludePatterns,
@@ -95,7 +95,7 @@ public class ScanCommand {
 
     public List<String> createCommandForProcessBuilder(IntLogger logger, ScanPaths scannerPaths, String specificRunOutputDirectoryPath) throws IllegalArgumentException, IntegrationException {
         command = new ArrayList<>();
-        commandKeysToKeyRelatedIndeces = new HashMap<>();
+        commandKeysToKeyRelatedIndices = new HashMap<>();
 
         logger.debug("Using this java installation : " + scannerPaths.getPathToJavaExecutable());
 
@@ -169,10 +169,10 @@ public class ScanCommand {
     }
 
     private void appendKeyValuePair(String key, String value) {
-        if (!commandKeysToKeyRelatedIndeces.containsKey(key)) {
-            commandKeysToKeyRelatedIndeces.put(key, new ArrayList<>());
+        if (!commandKeysToKeyRelatedIndices.containsKey(key)) {
+            commandKeysToKeyRelatedIndices.put(key, new ArrayList<>());
         }
-        List<Integer> indecesList = commandKeysToKeyRelatedIndeces.get(key);
+        List<Integer> indecesList = commandKeysToKeyRelatedIndices.get(key);
 
         indecesList.add(command.size());
         indecesList.add(command.size() + 1);
@@ -193,23 +193,23 @@ public class ScanCommand {
     }
 
     private void populateAdditionalScanArgumentsAndRemoveOverridden(ScanCommandArgumentParser parser) throws IntegrationException {
-        Set<Integer> overriddenArgIndexes = new HashSet<>();
+        Set<Integer> overriddenArgIndices = new HashSet<>();
 
         List<String> arguments = parser.parse(additionalScanArguments);
 
         for (String argument : arguments) {
             if (StringUtils.isNotBlank(argument)) {
-                if (commandKeysToKeyRelatedIndeces.containsKey(argument)) {
-                    overriddenArgIndexes.addAll(commandKeysToKeyRelatedIndeces.get(argument));
+                if (commandKeysToKeyRelatedIndices.containsKey(argument)) {
+                    overriddenArgIndices.addAll(commandKeysToKeyRelatedIndices.get(argument));
                 }
                 appendSingleArgument(argument);
             }
         }
 
-        if (overriddenArgIndexes.size() > 0) {
+        if (!overriddenArgIndices.isEmpty()) {
             List<String> updatedCommand = new ArrayList<>();
             for (int i = 0; i < command.size(); i++) {
-                if (!overriddenArgIndexes.contains(i)) {
+                if (!overriddenArgIndices.contains(i)) {
                     updatedCommand.add(command.get(i));
                 }
             }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandArgumentParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandArgumentParser.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandCallable.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandCallable.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandQuoteParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandQuoteParser.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandRunner.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommandRunner.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanPaths.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanPaths.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanTarget.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanTarget.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScannerInstaller.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScannerZipInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScannerZipInstaller.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadBatch.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadBatchOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadBatchOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadOutput.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadOutput.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadTarget.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/upload/UploadTarget.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckConnectionResult.java
+++ b/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckConnectionResult.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfig.java
+++ b/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfig.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfigBuilder.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfigKeys.java
+++ b/src/main/java/com/synopsys/integration/blackduck/configuration/BlackDuckServerConfigKeys.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckApiException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckApiException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckIntegrationException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckIntegrationException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckItemTransformException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckItemTransformException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckTimeoutExceededException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/BlackDuckTimeoutExceededException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/FailureConditionException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/FailureConditionException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/MismatchedQuotesException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/MismatchedQuotesException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/ScanFailedException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/ScanFailedException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/exception/SignatureScannerInputException.java
+++ b/src/main/java/com/synopsys/integration/blackduck/exception/SignatureScannerInputException.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckMediaTypes.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckMediaTypes.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckPageDefinition.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckPageDefinition.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckPageResponse.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckPageResponse.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckQuery.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckQuery.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckRequestBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckRequestBuilder.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckRequestFilter.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckRequestFilter.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckUrl.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckUrl.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckUrlSearchTerm.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/BlackDuckUrlSearchTerm.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/ApiTokenBlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/ApiTokenBlackDuckHttpClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckCertificateInterceptor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckCertificateInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckHttpClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckRedirectStrategy.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/BlackDuckRedirectStrategy.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/CookieHeaderParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/CookieHeaderParser.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/CredentialsBlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/CredentialsBlackDuckHttpClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/DefaultBlackDuckHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/DefaultBlackDuckHttpClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/SignatureScannerClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/SignatureScannerClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/cache/CacheableResponse.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/cache/CacheableResponse.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/client/cache/CachingHttpClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/client/cache/CachingHttpClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckJsonTransformer.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckJsonTransformer.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponseTransformer.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponseTransformer.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponsesTransformer.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/BlackDuckResponsesTransformer.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/adapters/OffsetDateTimeTypeAdapter.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/adapters/OffsetDateTimeTypeAdapter.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/BlackDuckResponseResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/BlackDuckResponseResolver.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/BlackDuckResponseSubclassResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/BlackDuckResponseSubclassResolver.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/NotificationUserViewSubclassResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/NotificationUserViewSubclassResolver.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/NotificationViewSubclassResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/NotificationViewSubclassResolver.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/SimpleNotificationView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/http/transform/subclass/SimpleNotificationView.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/keystore/KeyStoreHelper.java
+++ b/src/main/java/com/synopsys/integration/blackduck/keystore/KeyStoreHelper.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
+++ b/src/main/java/com/synopsys/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckApiClient.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckServicesFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/BlackDuckServicesFactory.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/DataService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/DataService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/BlackDuckScanReadinessService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/BlackDuckScanReadinessService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/CodeLocationService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/CodeLocationService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ComponentService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ComponentService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/IacScanUploadService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/IacScanUploadService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/IssueService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/IssueService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/LicenseService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/LicenseService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/NotificationService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/NotificationService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/PolicyRuleService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/PolicyRuleService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectBomService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectBomService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectGetService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectGetService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectMappingService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectMappingService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectUsersService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/ProjectUsersService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/RoleService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/RoleService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/TagService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/TagService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserGroupService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserGroupService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserRoleService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserRoleService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/BlackDuckServerData.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/BlackDuckServerData.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionPolicyViolationCount.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionPolicyViolationCount.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionStatusCount.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionStatusCount.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionVulnerabilities.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ComponentVersionVulnerabilities.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/MatchedFilesModel.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/MatchedFilesModel.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/NotificationTaskRange.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/NotificationTaskRange.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/PolicyRuleExpressionSetBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/PolicyRuleExpressionSetBuilder.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/PolicyStatusDescription.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/PolicyStatusDescription.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectNameVersionGuess.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectNameVersionGuess.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectNameVersionGuesser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectNameVersionGuesser.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectSyncModel.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectSyncModel.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectVersionDescription.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectVersionDescription.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectVersionWrapper.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ProjectVersionWrapper.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/RiskProfileCounts.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/RiskProfileCounts.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/ScannerSplitStream.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/ScannerSplitStream.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/StreamRedirectThread.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/StreamRedirectThread.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/model/VersionBomComponentModel.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/model/VersionBomComponentModel.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/AcceptHeaderEditor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/AcceptHeaderEditor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckMultipleRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckMultipleRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckRequestBuilderEditor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckRequestBuilderEditor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckResponseRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckResponseRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckSingleRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckSingleRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckStringRequest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/BlackDuckStringRequest.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/NotificationEditor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/NotificationEditor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/service/request/PagingDefaultsEditor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/request/PagingDefaultsEditor.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/useragent/BlackDuckCommon.java
+++ b/src/main/java/com/synopsys/integration/blackduck/useragent/BlackDuckCommon.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/useragent/UserAgentBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/useragent/UserAgentBuilder.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/useragent/UserAgentItem.java
+++ b/src/main/java/com/synopsys/integration/blackduck/useragent/UserAgentItem.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
+++ b/src/main/java/com/synopsys/integration/blackduck/version/BlackDuckVersion.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/resources/riskreport/web/js/BlackDuckBomReportFunctions.js
+++ b/src/main/resources/riskreport/web/js/BlackDuckBomReportFunctions.js
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/resources/riskreport/web/js/BlackDuckRiskReport.js
+++ b/src/main/resources/riskreport/web/js/BlackDuckRiskReport.js
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/resources/riskreport/web/js/Sortable.js
+++ b/src/main/resources/riskreport/web/js/Sortable.js
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/resources/riskreport/web/js/jquery-3.6.4.min.js
+++ b/src/main/resources/riskreport/web/js/jquery-3.6.4.min.js
@@ -1,7 +1,7 @@
 /*
  * blackduck-common
  *
- * Copyright (c) 2023 Synopsys, Inc.
+ * Copyright (c) 2024 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */


### PR DESCRIPTION
Prior to this change, all additional arguments to scan command were treated as addition with no regard to what arguments may already be set.

This change ensures that key-value pairs get overridden in order to avoid conflicts and ambiguity.