### PR TITLE
DO NOT MERGE UNTIL DETECT 9.6.0

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/synopsys/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -22,7 +22,7 @@ import com.synopsys.integration.rest.exception.IntegrationRestException;
 import com.synopsys.integration.rest.response.Response;
 
 public class Bdio2RetryAwareStreamUploader {
-    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404);
+    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 409);
     private static final Integer TOO_MANY_REQUESTS_CODE = 429;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final Bdio2StreamUploader bdio2StreamUploader;


### PR DESCRIPTION
 Adds 409 to the list of non-retryable exit codes. 