### PR TITLE
Add method for fetching server-only roles assigned to user

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/RoleService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/RoleService.java
@@ -51,7 +51,7 @@ public class RoleService extends DataService {
         return blackDuckApiClient.getAllResponses(requestMultiple);
     }
 
-    private BlackDuckRequestFilter createScopeFilter(String scope) {
+    public static BlackDuckRequestFilter createScopeFilter(String scope) {
         return BlackDuckRequestFilter.createFilterWithSingleValue("scope", scope);
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserGroupService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/dataservice/UserGroupService.java
@@ -19,12 +19,15 @@ import java.util.function.Predicate;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.response.AssignedProjectView;
 import com.synopsys.integration.blackduck.api.manual.view.ProjectView;
+import com.synopsys.integration.blackduck.http.BlackDuckRequestBuilder;
 import com.synopsys.integration.blackduck.api.generated.view.RoleAssignmentView;
+import com.synopsys.integration.blackduck.api.generated.view.RoleView;
 import com.synopsys.integration.blackduck.api.generated.view.UserGroupView;
 import com.synopsys.integration.blackduck.api.generated.view.UserView;
 import com.synopsys.integration.blackduck.api.manual.temporary.component.UserGroupRequest;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.DataService;
+import com.synopsys.integration.blackduck.service.request.BlackDuckMultipleRequest;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.HttpUrl;
@@ -114,6 +117,20 @@ public class UserGroupService extends DataService {
         roleSet.addAll(getRolesForUser(userView));
         roleSet.addAll(getInheritedRolesForUser(userView));
         return new ArrayList(roleSet);
+    }
+
+    public List<RoleAssignmentView> getServerRolesForUser(UserView userView) throws IntegrationException {
+        BlackDuckRequestBuilder blackDuckRequestBuilder = new BlackDuckRequestBuilder()
+                                                              .commonGet()
+                                                              .addBlackDuckFilter(RoleService.createScopeFilter(
+                                                                  RoleService.SERVER_SCOPE
+                                                              ));
+
+        BlackDuckMultipleRequest<RoleAssignmentView> requestMultiple = blackDuckRequestBuilder.buildBlackDuckRequest(
+            userView.metaRolesLink()
+        );
+
+        return blackDuckApiClient.getAllResponses(requestMultiple);
     }
 
     public Optional<UserGroupView> getGroupByName(String groupName) throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/blackduck/service/dataservice/UserServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/service/dataservice/UserServiceTestIT.java
@@ -62,6 +62,19 @@ public class UserServiceTestIT {
     }
 
     @Test
+    public void getServerRolesForUserTestIT() throws IntegrationException {
+        UserGroupService service = blackDuckServicesFactory.createUserGroupService();
+        String username = UserServiceTestIT.INT_HTTP_CLIENT_TEST_HELPER.getTestUsername();
+
+        UserView userView = service.getUserByUsername(username).get();
+
+        assertNotNull(userView);
+
+        List<RoleAssignmentView> serverRolesForUser = service.getServerRolesForUser(userView);
+        assertTrue(serverRolesForUser.size() > 0);
+    }
+
+    @Test
     public void testAddingGroupToProject() throws IntegrationException {
         String userGroupName = "user-group-test" + System.currentTimeMillis();
         ProjectView projectView = null;


### PR DESCRIPTION
Add method for fetching server-only roles assigned to user.
This will allow detect to log this limited set of roles instead of what it does currently, which is fetch potentially thousands of project-specific roles.

This will be used by Detect as part of the following change: https://github.com/blackducksoftware/synopsys-detect/pull/1144