### PR TITLE
Add csv archive support to signature scan invocation

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -231,4 +231,8 @@ public class ScanBatch extends Stringable implements Buildable {
     public String getCorrelationId() {
         return correlationId;
     }
+    
+    public boolean isCsvArchive() {
+    	return isCsvArchive();
+    }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -233,6 +233,6 @@ public class ScanBatch extends Stringable implements Buildable {
     }
     
     public boolean isCsvArchive() {
-    	return isCsvArchive();
+    	return csvArchive;
     }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -60,11 +60,12 @@ public class ScanBatch extends Stringable implements Buildable {
     @Nullable
     private final String correlationId;
     private final String bomCompareMode;
+    private final boolean csvArchive;
 
     public ScanBatch(File outputDirectory, boolean cleanupOutput, int scanMemoryInMegabytes, boolean dryRun, boolean debug, boolean verbose,
         String scanCliOpts, String additionalScanArguments, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, HttpUrl blackDuckUrl,
         String blackDuckUsername, String blackDuckPassword, String blackDuckApiToken, ProxyInfo proxyInfo, boolean runInsecure, String projectName, String projectVersionName,
-        List<ScanTarget> scanTargets, boolean isRapid, ReducedPersistence reducedPersistence, @Nullable String correlationId, String bomCompareMode) {
+        List<ScanTarget> scanTargets, boolean isRapid, ReducedPersistence reducedPersistence, @Nullable String correlationId, String bomCompareMode, boolean csvArchive) {
         this.outputDirectory = outputDirectory;
         this.cleanupOutput = cleanupOutput;
         this.scanMemoryInMegabytes = scanMemoryInMegabytes;
@@ -88,6 +89,7 @@ public class ScanBatch extends Stringable implements Buildable {
         this.reducedPersistence = reducedPersistence;
         this.correlationId = correlationId;
         this.bomCompareMode = bomCompareMode;
+        this.csvArchive = csvArchive;
     }
 
     /**
@@ -129,7 +131,7 @@ public class ScanBatch extends Stringable implements Buildable {
         ScanCommand scanCommand = new ScanCommand(signatureScannerInstallDirectory, commandOutputDirectory, commandDryRun, proxyInfo, scanCliOptsToUse, scanMemoryInMegabytes, commandScheme, commandHost,
             blackDuckApiToken, blackDuckUsername, blackDuckPassword, commandPort, runInsecure, scanTarget.getCodeLocationName(), blackDuckOnlineProperties,
             individualFileMatching, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, isRapid, reducedPersistence, correlationId,
-            bomCompareMode);
+            bomCompareMode, csvArchive);
         scanCommands.add(scanCommand);
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -64,13 +64,15 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private List<ScanTarget> scanTargets = new ArrayList<>();
     
     private String bomCompareMode;
+    
+    private boolean csvArchive;
 
     @Override
     protected ScanBatch buildWithoutValidation() {
         BlackDuckOnlineProperties blackDuckOnlineProperties = new BlackDuckOnlineProperties(snippetMatching, uploadSource, licenseSearch, copyrightSearch);
         return new ScanBatch(outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments,
             blackDuckOnlineProperties, individualFileMatching, blackDuckUrl, blackDuckUsername, blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate,
-            projectName, projectVersionName, scanTargets, isRapid, reducedPersistence, correlationId, bomCompareMode);
+            projectName, projectVersionName, scanTargets, isRapid, reducedPersistence, correlationId, bomCompareMode, csvArchive);
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -384,4 +384,9 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     	this.bomCompareMode = bomCompareMode;
     	return this;
     }
+    
+    public ScanBatchBuilder csvArchive(boolean csvArchive) {
+    	this.csvArchive = csvArchive;
+    	return this;
+    }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -54,6 +54,7 @@ public class ScanCommand {
     @Nullable
     private final String correlationId;
     private final String bomCompareMode;
+    private final boolean csvArchive;
 
     private List<String> command;
 
@@ -63,7 +64,7 @@ public class ScanCommand {
         String blackDuckUsername, String blackDuckPassword, int port, boolean runInsecure, String name, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, Set<String> excludePatterns,
         String additionalScanArguments, String targetPath, boolean verbose, boolean debug, String projectName, String versionName, boolean isRapid,
         ReducedPersistence reducedPersistence,
-        @Nullable String correlationId, String bomCompareMode) {
+        @Nullable String correlationId, String bomCompareMode, boolean csvArchive) {
         this.signatureScannerInstallDirectory = signatureScannerInstallDirectory;
         this.outputDirectory = outputDirectory;
         this.dryRun = dryRun;
@@ -91,6 +92,7 @@ public class ScanCommand {
         this.reducedPersistence = reducedPersistence;
         this.correlationId = correlationId;
         this.bomCompareMode = bomCompareMode;
+        this.csvArchive = csvArchive;
     }
 
     public List<String> createCommandForProcessBuilder(IntLogger logger, ScanPaths scannerPaths, String specificRunOutputDirectoryPath) throws IllegalArgumentException, IntegrationException {
@@ -123,6 +125,10 @@ public class ScanCommand {
         }
         if (debug) {
             appendSingleArgument("--debug");
+        }
+        
+        if (csvArchive) {
+        	appendKeyValuePair("--outputFormat", "csv");
         }
 
         appendKeyValuePair("--logDir", specificRunOutputDirectoryPath);

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -128,7 +128,7 @@ public class ScanCommand {
         }
         
         if (csvArchive) {
-        	appendKeyValuePair("--outputFormat", "csv");
+            appendKeyValuePair("--outputFormat", "csv");
         }
 
         appendKeyValuePair("--logDir", specificRunOutputDirectoryPath);


### PR DESCRIPTION
This allows for passing a csv archive option to the signature scanner so that csv files can be created. Detect will begin doing this in offline mode so that users have access to the files.