### PR TITLE
Update ToolsApiScannerInstaller to add BD server's certificate to the…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ project.ext.moduleName = 'com.synopsys.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '66.2.25-SNAPSHOT'
+version = '66.2.26-SNAPSHOT'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -201,8 +201,10 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
                 oneJar.setExecutable(true);
                 scanExecutable.setExecutable(true);
 
-                if (connectAndGetServerCertificate(downloadUrl)!= null) {
-                    keyStoreHelper.updateKeyStoreWithServerCertificate(downloadUrl.url().getHost(), connectAndGetServerCertificate(downloadUrl), scanPaths.getPathToCacerts());
+
+                Certificate certificate = connectAndGetServerCertificate(downloadUrl);
+                if (certificate != null) {
+                    keyStoreHelper.updateKeyStoreWithServerCertificate(downloadUrl.url().getHost(), certificate, scanPaths.getPathToCacerts());
                 }
 
                 logger.info("Black Duck Signature Scanner downloaded successfully.");
@@ -239,8 +241,11 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             httpsConnection.connect();
             Certificate[] certificates = httpsConnection.getServerCertificates();
             httpsConnection.disconnect();
-
-            return certificates[0];
+            if (certificates.length > 0) {
+                return certificates[0];
+            } else {
+                throw new IOException();
+            }
         } catch (IOException e) {
             logger.errorAndDebug("Could not get Black Duck server certificate which is required for managing the local keystore - communicating to the server will have to be configured manually: " + e.getMessage(), e);
             return null;

--- a/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ToolsApiScannerInstallerTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/ToolsApiScannerInstallerTest.java
@@ -7,6 +7,7 @@ import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfigBuilder;
 import com.synopsys.integration.blackduck.http.client.BlackDuckHttpClient;
 import com.synopsys.integration.blackduck.http.client.TestingPropertyKey;
+import com.synopsys.integration.blackduck.keystore.KeyStoreHelper;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.blackduck.service.dataservice.BlackDuckRegistrationService;
 import com.synopsys.integration.log.BufferedIntLogger;
@@ -51,7 +52,7 @@ public class ToolsApiScannerInstallerTest {
         CleanupZipExpander cleanupZipExpander = new CleanupZipExpander(logger);
         File downloadTarget = new File(signatureScannerDownloadPath);
 
-        ToolsApiScannerInstaller toolsApiScannerInstaller = new ToolsApiScannerInstaller(logger, blackDuckHttpClient, cleanupZipExpander, scanPathsUtility, new HttpUrl(blackDuckUrl),
+        ToolsApiScannerInstaller toolsApiScannerInstaller = new ToolsApiScannerInstaller(logger, blackDuckHttpClient, cleanupZipExpander, scanPathsUtility, new KeyStoreHelper(logger), new HttpUrl(blackDuckUrl),
                 operatingSystemType,
                 downloadTarget);
         toolsApiScannerInstaller.installOrUpdateScanner();

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/InstallAndRunSignatureScannerTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/InstallAndRunSignatureScannerTestIT.java
@@ -73,7 +73,7 @@ class InstallAndRunSignatureScannerTestIT {
         FileUtils.deleteQuietly(scannerDirectoryPath);
     }
 
-//    @Test
+    @Test
     void testInstallingAndRunningSignatureScanner() throws IOException, InterruptedException, IntegrationException {
         // here, we do not want to automatically trust the server's certificate
         BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = intHttpClientTestHelper.getBlackDuckServerConfigBuilder();


### PR DESCRIPTION
Update ToolsApiScannerInstaller to add the BD server's certificate to the Java keystore that comes inside the scan-cli ZIP. Otherwise we will get the following error when Detect invokes the downloaded scan-cli: 


2024-07-26 04:49:40 MDT ERROR [pool-3-thread-1-Stream Redirect Thread] --- ERROR: An error occurred - [ERR03_1001 Resource Allocation Error | Service: Unknown Service | Failed to establish the validity of the server's certificate (use --insecure to ignore).]  sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
