### PR TITLE
Using a single version file regardless of API used for download.

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 public abstract class ApiScannerInstaller implements ScannerInstaller {
     public static final String BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY = "Black_Duck_Scan_Installation";
-
+    public static final String VERSION_FILENAME = "blackDuckVersion.txt";
 
     @Override
     public abstract File installOrUpdateScanner() throws BlackDuckIntegrationException;

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -43,8 +43,6 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     private static final String LINUX_PLATFORM_PARAMETER_VALUE = "linux";
     private static final String WINDOWS_PLATFORM_PARAMETER_VALUE = "windows";
 
-    public static final String SCAN_CLI_VERSION_FILENAME = "scan-cli-version.txt";
-
     private final IntLogger logger;
     private final BlackDuckHttpClient blackDuckHttpClient;
     private final CleanupZipExpander cleanupZipExpander;
@@ -98,10 +96,10 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             }
         }
 
-        File scannerExpansionDirectory = new File(installDirectory, ToolsApiScannerInstaller.BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
+        File scannerExpansionDirectory = new File(installDirectory, BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
         scannerExpansionDirectory.mkdirs();
 
-        File versionFile = new File(scannerExpansionDirectory, ToolsApiScannerInstaller.SCAN_CLI_VERSION_FILENAME);
+        File versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
         HttpUrl downloadUrl = getDownloadUrl();
 
         try {
@@ -112,7 +110,6 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
                 // Version file creation should happen after successful download
                 logger.debug("The version file has not been created yet so creating it now.");
                 FileUtils.writeStringToFile(versionFile, scannerVersion, Charset.defaultCharset());
-                removeOldVersionFileIfExists(scannerExpansionDirectory);
                 return installDirectory;
             }
             // A version file exists, so we have to compare to determine if a download should occur.
@@ -219,20 +216,6 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             }
         }
     }
-
-    /**
-     * Deletes legacy version file that may be left behind if client had previously installed scan-cli using {@link ZipApiScannerInstaller}
-     * @param scannerExpansionDirectory
-     */
-    private void removeOldVersionFileIfExists(File scannerExpansionDirectory) {
-        try {
-            File oldVersionFile = new File(scannerExpansionDirectory, ZipApiScannerInstaller.VERSION_FILENAME);
-            oldVersionFile.delete();
-        } catch (Exception e) {
-            logger.trace("Could not delete old Signature Scanner version file.");
-        }
-    }
-
 
     private Certificate connectAndGetServerCertificate(HttpUrl httpsServer) {
         HttpsURLConnection httpsConnection = null;

--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ZipApiScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ZipApiScannerInstaller.java
@@ -34,7 +34,6 @@ public class ZipApiScannerInstaller extends ApiScannerInstaller {
     public static final String WINDOWS_SIGNATURE_SCANNER_DOWNLOAD_URL_SUFFIX = "download/scan.cli-windows.zip";
     public static final String MAC_SIGNATURE_SCANNER_DOWNLOAD_URL_SUFFIX = "download/scan.cli-macosx.zip";
 
-    public static final String VERSION_FILENAME = "blackDuckVersion.txt";
 
     private final IntLogger logger;
     private final SignatureScannerClient signatureScannerClient;
@@ -92,10 +91,10 @@ public class ZipApiScannerInstaller extends ApiScannerInstaller {
             }
         }
 
-        File scannerExpansionDirectory = new File(installDirectory, ZipApiScannerInstaller.BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
+        File scannerExpansionDirectory = new File(installDirectory, BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
         scannerExpansionDirectory.mkdirs();
 
-        File versionFile = new File(scannerExpansionDirectory, ZipApiScannerInstaller.VERSION_FILENAME);
+        File versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
         HttpUrl downloadUrl = getDownloadUrl();
 
         try {


### PR DESCRIPTION
For simplicity sake, just using one text file: blackDuckVersion.txt regardless of which API was used to download the scanner. 

This is the same version file as we have always used, so as far as the Detect output files are concerned, all is the same regardless of which API was used under the hood .
  
IDETECT-4434