### PR TITLE
fix (ToolsApiScannerInstaller): Correctly form request URL when Black Duck URL has a trailing '/' character. 

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/synopsys/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -134,8 +134,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
         StringBuilder url = new StringBuilder(blackDuckServerUrl.string());
         if (!blackDuckServerUrl.string().endsWith("/")) {
             url.append("/");
-            url.append(LATEST_SCAN_CLI_TOOL_DOWNLOAD_URL);
         }
+        url.append(LATEST_SCAN_CLI_TOOL_DOWNLOAD_URL);
 
         String platform;
         if (OperatingSystemType.MAC == operatingSystemType) {


### PR DESCRIPTION
Fix bug that fails to correctly form the URL for the scan-cli download request when the blackduck.url provided has a trailing / character. Fixes IDETECT-4461