### PR TITLE
Changes related to refactoring and fixing ITs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ## Overview ##
 The blackduck-common library supplies convenient communication with a Black Duck server through REST API's as well as providing convenient ways to download the CLI and execute it.
-To run integration tests, create a test.properties file under src/test/resources and populate the relevant key-value pairs (See TestingPropertyKey enum for possible keys). 
 
 ## Build ##
 
@@ -15,3 +14,7 @@ You can download the latest release from Maven Central.
 
 ## Documentation ##
 All documentation for blackduck-common can be found on the base project:  https://github.com/blackducksoftware/blackduck-common/wiki
+
+## Tests ##
+To run integration tests, create a test.properties file under src/test/resources and populate the relevant key-value pairs (See TestingPropertyKey enum for possible keys). 
+

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
@@ -2,7 +2,6 @@ package com.synopsys.integration.blackduck.comprehensive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,17 +10,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.synopsys.integration.blackduck.http.client.TestingPropertyKey;
-import com.synopsys.integration.log.BufferedIntLogger;
 import com.synopsys.integration.log.IntLogger;
-import com.synopsys.integration.log.LogLevel;
-import com.synopsys.integration.log.PrintStreamIntLogger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.synopsys.integration.blackduck.TimingExtension;
-import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.UserView;
 import com.synopsys.integration.blackduck.api.manual.component.ProjectNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.component.ProjectVersionNotificationContent;
@@ -51,8 +45,8 @@ public class NotificationsTestIT {
         IntLogger logger = intHttpClientTestHelper.createIntLogger(intHttpClientTestHelper.getTestLogLevel());
         BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory(logger);
 
-        String projectName = "notifications_test_" + System.currentTimeMillis(); // TODO add afterAll() to clean any projects/version created
-        String projectVersionName = "notifications_test_version_" + System.currentTimeMillis(); // TOME left behind on 25 notifications_test_ projects in butler
+        String projectName = "notifications_test_" + System.currentTimeMillis();
+        String projectVersionName = "notifications_test_version_" + System.currentTimeMillis();
         String projectVersion2Name = "notifications_test_version2_" + System.currentTimeMillis();
 
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
@@ -74,28 +68,8 @@ public class NotificationsTestIT {
         ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel);
         ProjectVersionWrapper projectVersionWrapper2 = projectService.syncProjectAndVersion(projectSyncModel2, true);
 
-        // DELETE
-        blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView()); // TOME looks to be successful, v#2 on BD
-        blackDuckApiClient.delete(projectVersionWrapper.getProjectView()); // TOME deleting #1, fails intermittently and leaves project version behind when test case exits
-        // TODO option 1: sleep and/or retry
-        // TODO option 2: just retry on jenkins .. though sometimes it very consistently fails ... ?
-        // TODO change the notifications to something else since this test is really about just checking the correct notifications are sent?
-            // other possible notifications:
-        /**
-         *     BOM_EDIT,
-         *     LICENSE_LIMIT,
-         *     POLICY_OVERRIDE,
-         *     PROJECT,
-         *     PROJECT_VERSION,
-         *     RULE_VIOLATION,
-         *     RULE_VIOLATION_CLEARED,
-         *     VERSION_BOM_CODE_LOCATION_BOM_COMPUTED,
-         *     VULNERABILITY;
-         */
-
         // two project version create
-        // one project version delete, one project delete
-        Set<String> expectedKeys = new HashSet(Arrays.asList("CREATE" + projectVersionName, "CREATE" + projectVersion2Name, "DELETE" + projectName, "DELETE" + projectVersion2Name));
+        Set<String> expectedKeys = new HashSet(Arrays.asList("CREATE" + projectVersionName, "CREATE" + projectVersion2Name));
 
         Set<String> foundKeys = new HashSet<>();
         long start = System.currentTimeMillis();
@@ -122,6 +96,10 @@ public class NotificationsTestIT {
         }
 
         assertEquals(expectedKeys, foundKeys);
+
+        // CLEAN UP
+        blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView());
+        blackDuckApiClient.delete(projectVersionWrapper.getProjectView());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
@@ -51,8 +51,8 @@ public class NotificationsTestIT {
         IntLogger logger = intHttpClientTestHelper.createIntLogger(intHttpClientTestHelper.getTestLogLevel());
         BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory(logger);
 
-        String projectName = "notifications_test_" + System.currentTimeMillis(); // TOME also fails to clean up
-        String projectVersionName = "notifications_test_version_" + System.currentTimeMillis();
+        String projectName = "notifications_test_" + System.currentTimeMillis(); // TODO add afterAll() to clean any projects/version created
+        String projectVersionName = "notifications_test_version_" + System.currentTimeMillis(); // TOME left behind on 25 notifications_test_ projects in butler
         String projectVersion2Name = "notifications_test_version2_" + System.currentTimeMillis();
 
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
@@ -71,13 +71,27 @@ public class NotificationsTestIT {
         notificationTypes.add(NotificationType.PROJECT_VERSION.name());
 
         // CREATE
-        ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel); // TOME did this succeed? prob not b/c it already exists?
-        logger.info("created project version 1");
+        ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel);
         ProjectVersionWrapper projectVersionWrapper2 = projectService.syncProjectAndVersion(projectSyncModel2, true);
 
         // DELETE
         blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView()); // TOME looks to be successful, v#2 on BD
-        blackDuckApiClient.delete(projectVersionWrapper.getProjectView()); // TOME deleting #1
+        blackDuckApiClient.delete(projectVersionWrapper.getProjectView()); // TOME deleting #1, fails intermittently and leaves project version behind when test case exits
+        // TODO option 1: sleep and/or retry
+        // TODO option 2: just retry on jenkins .. though sometimes it very consistently fails ... ?
+        // TODO change the notifications to something else since this test is really about just checking the correct notifications are sent?
+            // other possible notifications:
+        /**
+         *     BOM_EDIT,
+         *     LICENSE_LIMIT,
+         *     POLICY_OVERRIDE,
+         *     PROJECT,
+         *     PROJECT_VERSION,
+         *     RULE_VIOLATION,
+         *     RULE_VIOLATION_CLEARED,
+         *     VERSION_BOM_CODE_LOCATION_BOM_COMPUTED,
+         *     VULNERABILITY;
+         */
 
         // two project version create
         // one project version delete, one project delete

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
@@ -47,7 +47,6 @@ public class NotificationsTestIT {
 
         String projectName = "notifications_test_" + System.currentTimeMillis();
         String projectVersionName = "notifications_test_version_" + System.currentTimeMillis();
-        String projectVersion2Name = "notifications_test_version2_" + System.currentTimeMillis();
 
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
         ProjectService projectService = blackDuckServicesFactory.createProjectService();
@@ -55,7 +54,6 @@ public class NotificationsTestIT {
         UserService userService = blackDuckServicesFactory.createUserService();
 
         ProjectSyncModel projectSyncModel = ProjectSyncModel.createWithDefaults(projectName, projectVersionName);
-        ProjectSyncModel projectSyncModel2 = ProjectSyncModel.createWithDefaults(projectName, projectVersion2Name);
 
         UserView currentUser = userService.findCurrentUser();
         Date startDate = notificationService.getLatestUserNotificationDate(currentUser);
@@ -66,10 +64,9 @@ public class NotificationsTestIT {
 
         // CREATE
         ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel);
-        ProjectVersionWrapper projectVersionWrapper2 = projectService.syncProjectAndVersion(projectSyncModel2, true);
 
-        // two project version create
-        Set<String> expectedKeys = new HashSet(Arrays.asList("CREATE" + projectVersionName, "CREATE" + projectVersion2Name));
+        // one project version create
+        Set<String> expectedKeys = new HashSet(Arrays.asList("CREATE" + projectVersionName));
 
         Set<String> foundKeys = new HashSet<>();
         long start = System.currentTimeMillis();
@@ -79,12 +76,7 @@ public class NotificationsTestIT {
             NotificationEditor notificationEditor = new NotificationEditor(startDate, endDate, notificationTypes);
             List<NotificationUserView> notifications = notificationService.getAllUserNotifications(currentUser, notificationEditor);
             for (NotificationUserView notificationUserView : notifications) {
-                if (notificationUserView instanceof ProjectNotificationUserView) {
-                    ProjectNotificationContent content = ((ProjectNotificationUserView) notificationUserView).getContent();
-                    if (projectName.equals(content.getProjectName())) {
-                        foundKeys.add(content.getOperationType() + content.getProjectName());
-                    }
-                } else if (notificationUserView instanceof ProjectVersionNotificationUserView) {
+                if (notificationUserView instanceof ProjectVersionNotificationUserView) {
                     ProjectVersionNotificationContent content = ((ProjectVersionNotificationUserView) notificationUserView).getContent();
                     if (projectName.equals(content.getProjectName())) {
                         foundKeys.add(content.getOperationType() + content.getProjectVersionName());
@@ -98,7 +90,6 @@ public class NotificationsTestIT {
         assertEquals(expectedKeys, foundKeys);
 
         // CLEAN UP
-        blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView());
         blackDuckApiClient.delete(projectVersionWrapper.getProjectView());
     }
 

--- a/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
+++ b/src/test/java/com/synopsys/integration/blackduck/comprehensive/NotificationsTestIT.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.blackduck.comprehensive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,6 +11,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.synopsys.integration.blackduck.http.client.TestingPropertyKey;
+import com.synopsys.integration.log.BufferedIntLogger;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.log.PrintStreamIntLogger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,9 +48,10 @@ public class NotificationsTestIT {
 
     @Test
     public void testProjectNotifications() throws IntegrationException, InterruptedException {
-        BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory();
+        IntLogger logger = intHttpClientTestHelper.createIntLogger(intHttpClientTestHelper.getTestLogLevel());
+        BlackDuckServicesFactory blackDuckServicesFactory = intHttpClientTestHelper.createBlackDuckServicesFactory(logger);
 
-        String projectName = "notifications_test_" + System.currentTimeMillis();
+        String projectName = "notifications_test_" + System.currentTimeMillis(); // TOME also fails to clean up
         String projectVersionName = "notifications_test_version_" + System.currentTimeMillis();
         String projectVersion2Name = "notifications_test_version2_" + System.currentTimeMillis();
 
@@ -64,12 +71,13 @@ public class NotificationsTestIT {
         notificationTypes.add(NotificationType.PROJECT_VERSION.name());
 
         // CREATE
-        ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel);
+        ProjectVersionWrapper projectVersionWrapper = projectService.syncProjectAndVersion(projectSyncModel); // TOME did this succeed? prob not b/c it already exists?
+        logger.info("created project version 1");
         ProjectVersionWrapper projectVersionWrapper2 = projectService.syncProjectAndVersion(projectSyncModel2, true);
 
         // DELETE
-        blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView());
-        blackDuckApiClient.delete(projectVersionWrapper.getProjectView());
+        blackDuckApiClient.delete(projectVersionWrapper2.getProjectVersionView()); // TOME looks to be successful, v#2 on BD
+        blackDuckApiClient.delete(projectVersionWrapper.getProjectView()); // TOME deleting #1
 
         // two project version create
         // one project version delete, one project delete

--- a/src/test/java/com/synopsys/integration/blackduck/http/client/IntHttpClientTestHelper.java
+++ b/src/test/java/com/synopsys/integration/blackduck/http/client/IntHttpClientTestHelper.java
@@ -80,6 +80,11 @@ public class IntHttpClientTestHelper {
         return getBlackDuckServerConfigBuilder().build();
     }
 
+    public LogLevel getTestLogLevel() {
+        // defaults to INFO if none or invalid value is provided in test.properties
+        return LogLevel.fromString(IntHttpClientTestHelper.testProperties.getProperty(TestingPropertyKey.INTEGRATION_TEST_LOG_LEVEL.toString()));
+    }
+
     public BlackDuckServerConfigBuilder getBlackDuckServerConfigBuilder() {
         BlackDuckServerConfigBuilder builder;
 

--- a/src/test/java/com/synopsys/integration/blackduck/http/client/TestingPropertyKey.java
+++ b/src/test/java/com/synopsys/integration/blackduck/http/client/TestingPropertyKey.java
@@ -51,7 +51,8 @@ public enum TestingPropertyKey {
     TEST_VULNERABLE_COMPONENT_NAME,
     TEST_VULNERABLE_COMPONENT_MIN_VULNERABILITIES,
     TEST_VULNERABLE_COMPONENT_VULNERABILITY_NAME,
-    LOG_DETAILS_TO_CONSOLE;
+    LOG_DETAILS_TO_CONSOLE,
+    INTEGRATION_TEST_LOG_LEVEL;
 
     public String fromEnvironment() {
         return System.getenv(name());


### PR DESCRIPTION
Fixes an intermittently failing IT: IDETECT-4473

Please see ticket comment for details but in summary: Project/project version creations followed immediately by a deletion leads to a race condition. Other notification types appear to come from Hub backend and I did not see any APIs this test case could call on to trigger one of the other available types of notifications. The DELETE has been moved to the end of the test case as a clean up. Only one version is created instead of two because even after notifications are delivered and asserted, a race condition still happened when cleaning up. 