### PR TITLE
Remove full snippet matching and full snippet only matching for signature scans

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/BlackDuckOnlineProperties.java
@@ -20,7 +20,6 @@ public class BlackDuckOnlineProperties {
 
     private final boolean snippetMatchingFlag;
     private final boolean snippetMatchingOnlyFlag;
-    private final boolean fullSnippetScanFlag;
 
     public BlackDuckOnlineProperties(SnippetMatching snippetMatchingMode, boolean uploadSource, boolean licenseSearch, boolean copyrightSearch) {
         this.snippetMatchingMode = snippetMatchingMode;
@@ -28,9 +27,8 @@ public class BlackDuckOnlineProperties {
         this.licenseSearch = licenseSearch;
         this.copyrightSearch = copyrightSearch;
 
-        snippetMatchingFlag = SnippetMatching.SNIPPET_MATCHING == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING == snippetMatchingMode;
-        snippetMatchingOnlyFlag = SnippetMatching.SNIPPET_MATCHING_ONLY == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING_ONLY == snippetMatchingMode;
-        fullSnippetScanFlag = SnippetMatching.FULL_SNIPPET_MATCHING == snippetMatchingMode || SnippetMatching.FULL_SNIPPET_MATCHING_ONLY == snippetMatchingMode;
+        snippetMatchingFlag = SnippetMatching.SNIPPET_MATCHING == snippetMatchingMode;
+        snippetMatchingOnlyFlag = SnippetMatching.SNIPPET_MATCHING_ONLY == snippetMatchingMode;
     }
 
     public boolean isOnlineCapabilityNeeded() {
@@ -43,10 +41,6 @@ public class BlackDuckOnlineProperties {
                 cmd.add("--snippet-matching");
             } else {
                 cmd.add("--snippet-matching-only");
-            }
-
-            if (fullSnippetScanFlag) {
-                cmd.add("--full-snippet-scan");
             }
         }
 
@@ -79,10 +73,6 @@ public class BlackDuckOnlineProperties {
 
     public boolean isSnippetMatchingOnly() {
         return snippetMatchingOnlyFlag;
-    }
-
-    public boolean isFullSnippetScan() {
-        return fullSnippetScanFlag;
     }
 
     public boolean isUploadSource() {

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -370,10 +370,6 @@ public class ScanCommand {
         return blackDuckOnlineProperties.isSnippetMatchingOnly();
     }
 
-    public boolean isFullSnippetScan() {
-        return blackDuckOnlineProperties.isFullSnippetScan();
-    }
-
     public boolean isUploadSource() {
         return blackDuckOnlineProperties.isUploadSource();
     }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/SnippetMatching.java
@@ -9,8 +9,5 @@ package com.blackduck.integration.blackduck.codelocation.signaturescanner.comman
 
 public enum SnippetMatching {
     SNIPPET_MATCHING,
-    SNIPPET_MATCHING_ONLY,
-    FULL_SNIPPET_MATCHING,
-    FULL_SNIPPET_MATCHING_ONLY
-
+    SNIPPET_MATCHING_ONLY
 }

--- a/src/test/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilderTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilderTest.java
@@ -81,7 +81,7 @@ public class ScanBatchBuilderTest {
     public void testUploadSourceWithSnippetMatching() {
         ScanBatchBuilder builder = createInitialValidBuilder();
         builder.uploadSource(true);
-        builder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY);
+        builder.snippetMatching(SnippetMatching.SNIPPET_MATCHING_ONLY);
         assertTrue(builder.isValid());
     }
 

--- a/src/test/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommandTest.java
@@ -61,49 +61,35 @@ public class ScanCommandTest {
     public void testSnippetScan() throws IntegrationException {
         scanBatchBuilder.snippetMatching(SnippetMatching.SNIPPET_MATCHING);
         List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, true, false, false);
+        assertSnippetCommands(commandList, true, false);
     }
 
     @Test
     public void testSnippetOnlyScan() throws IntegrationException {
         scanBatchBuilder.snippetMatching(SnippetMatching.SNIPPET_MATCHING_ONLY);
         List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, false);
-    }
-
-    @Test
-    public void testFullSnippetScan() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, true, false, true);
-    }
-
-    @Test
-    public void testFullSnippetOnlyScan() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY);
-        List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
+        assertSnippetCommands(commandList, false, true);
     }
 
     @Test
     public void testSnippetScanWithUploadSource() throws IntegrationException {
-        scanBatchBuilder.uploadSource(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY, true);
+        scanBatchBuilder.uploadSource(SnippetMatching.SNIPPET_MATCHING_ONLY, true);
         List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
+        assertSnippetCommands(commandList, false, true);
         assertUploadSource(commandList, true);
     }
 
     @Test
     public void testSnippetScanWithoutUploadSource() throws IntegrationException {
-        scanBatchBuilder.uploadSource(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY, false);
+        scanBatchBuilder.uploadSource(SnippetMatching.SNIPPET_MATCHING_ONLY, false);
         List<String> commandList = createCommandList();
-        assertSnippetCommands(commandList, false, true, true);
+        assertSnippetCommands(commandList, false, true);
         assertUploadSource(commandList, false);
     }
 
     @Test
     public void testSnippetScanLoggingWhenDryRun() throws IntegrationException {
-        scanBatchBuilder.snippetMatching(SnippetMatching.FULL_SNIPPET_MATCHING);
+        scanBatchBuilder.snippetMatching(SnippetMatching.SNIPPET_MATCHING);
 
         ScanBatch scanBatch = scanBatchBuilder.build();
         ScanCommand scanCommand = assertCommand(scanBatch);
@@ -346,10 +332,9 @@ public class ScanCommandTest {
         return scanCommands.get(0);
     }
 
-    private void assertSnippetCommands(List<String> commandList, boolean containsSnippetMatching, boolean containsSnippetMatchingOnly, boolean containsFullSnippetScan) {
+    private void assertSnippetCommands(List<String> commandList, boolean containsSnippetMatching, boolean containsSnippetMatchingOnly) {
         assertEquals(containsSnippetMatching, commandList.contains("--snippet-matching"));
         assertEquals(containsSnippetMatchingOnly, commandList.contains("--snippet-matching-only"));
-        assertEquals(containsFullSnippetScan, commandList.contains("--full-snippet-scan"));
     }
 
     private void assertLicenseSearch(List<String> commandList, boolean licenseSearch) {


### PR DESCRIPTION
Removing some options for signature scans that were deprecated in Detect 9 along with their corresponding usages and tests.