### PR TITLE
Fix Test Failure

### DIFF
--- a/src/test/java/com/blackduck/integration/blackduck/service/BlackDuckApiClientTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/service/BlackDuckApiClientTestIT.java
@@ -78,7 +78,7 @@ public class BlackDuckApiClientTestIT {
         BlackDuckSingleRequest<ProjectView> requestSingle = new BlackDuckSingleRequest<>(blackDuckRequestBuilder, projectViewUrlSingleResponse, new PagingDefaultsEditor(), new AcceptHeaderEditor(blackDuckMediaTypeDiscoveryVerifier));
         ProjectView retrievedById = blackDuckApiClient.getResponse(requestSingle);
         assertEquals(null, blackDuckMediaTypeDiscoveryVerifier.originalMediaType);
-        assertEquals("application/vnd.blackducksoftware.project-detail-7+json", blackDuckMediaTypeDiscoveryVerifier.discoveredMediaType);
+        assertEquals("application/vnd.blackducksoftware.project-detail-6+json", blackDuckMediaTypeDiscoveryVerifier.discoveredMediaType);
     }
 
     private class BlackDuckMediaTypeDiscoveryVerifier extends BlackDuckMediaTypeDiscovery {


### PR DESCRIPTION
Since we are using lower version of bd-common-api, this change would fix the failing test which was updated for 2023.10.0.5 release. Do not have much context on the cause of failure but this was how this test was fixed last time.