### PR TITLE
ComponentService: Fix-up obtaining a component view for a search result

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/service/dataservice/ComponentService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/dataservice/ComponentService.java
@@ -91,8 +91,8 @@ public class ComponentService extends DataService {
     }
 
     public Optional<ComponentView> getComponentView(ComponentsView searchResult) throws IntegrationException {
-        if (StringUtils.isNotBlank(searchResult.getVersion())) {
-            HttpUrl url = new HttpUrl(searchResult.getVersion());
+        if (StringUtils.isNotBlank(searchResult.getComponent())) {
+            HttpUrl url = new HttpUrl(searchResult.getComponent());
             return Optional.ofNullable(blackDuckApiClient.getResponse(url, ComponentView.class));
         } else {
             return Optional.empty();


### PR DESCRIPTION
The request construction accidentally uses the path to the `version` view, instead of to the `component` view. So, in case the given search result matches a `component`, but not a `version`, the result is empty. Fix that by using the right variable.