### PR TITLE
Bump bd-common-api version to 2023.4.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.7'
+    api 'com.blackduck.integration:blackduck-common-api:2023.10.0.7'
     api 'com.blackduck.integration:phone-home-client:7.0.0'
     api 'com.blackduck.integration:integration-bdio:27.0.0'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.10.0.7'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.8'
     api 'com.blackduck.integration:phone-home-client:7.0.0'
     api 'com.blackduck.integration:integration-bdio:27.0.0'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'


### PR DESCRIPTION
Pending release pipeline, brings in https://github.com/blackducksoftware/blackduck-common-api/pull/64

Due to IDETECT-4497, we are using release/v2023.4.2.7.x in bd-common-api as the base branch for IDETECT-4262. 