### PR TITLE
Reduce excessive logs when non-admin users fetch registration ID

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
+++ b/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
@@ -69,8 +69,12 @@ public class BlackDuckPhoneHomeHelper {
     }
 
     public PhoneHomeResponse handlePhoneHome(String integrationRepoName, String integrationVersion, Map<String, String> metaData, String... artifactModules) {
+        return handlePhoneHome(integrationRepoName, integrationVersion, metaData, true, artifactModules);
+    }
+
+    public PhoneHomeResponse handlePhoneHome(String integrationRepoName, String integrationVersion, Map<String, String> metaData, boolean isAdminOperationAllowed, String... artifactModules) {
         try {
-            PhoneHomeRequestBody phoneHomeRequestBody = createPhoneHomeRequestBody(integrationRepoName, integrationVersion, metaData, artifactModules);
+            PhoneHomeRequestBody phoneHomeRequestBody = createPhoneHomeRequestBody(integrationRepoName, integrationVersion, metaData, isAdminOperationAllowed, artifactModules);
             return phoneHomeService.phoneHome(phoneHomeRequestBody, getEnvironmentVariables());
         } catch (Exception e) {
             logger.debug("Problem phoning home: " + e.getMessage(), e);
@@ -79,13 +83,15 @@ public class BlackDuckPhoneHomeHelper {
     }
 
     private PhoneHomeRequestBody createPhoneHomeRequestBody(String integrationRepoName, String integrationVersion, Map<String, String> metaData, String... artifactModules) {
+        return createPhoneHomeRequestBody(integrationRepoName, integrationVersion, metaData, true, artifactModules);
+    }
+
+    private PhoneHomeRequestBody createPhoneHomeRequestBody(String integrationRepoName, String integrationVersion, Map<String, String> metaData, boolean isAdminOperationAllowed, String... artifactModules) {
         String registrationKey = PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE;
         String blackDuckUrl = PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE;
         String blackDuckVersion = PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE;
 
         try {
-            boolean isAdminOperationAllowed = Boolean.parseBoolean(metaData.getOrDefault("isAdminOperationAllowed", "false"));
-            metaData.remove("isAdminOperationAllowed");
             BlackDuckServerData blackDuckServerData = blackDuckRegistrationService.getBlackDuckServerData(isAdminOperationAllowed);
             registrationKey = blackDuckServerData.getRegistrationKey().orElse(PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE);
             blackDuckUrl = blackDuckServerData.getUrl().string();
@@ -111,5 +117,4 @@ public class BlackDuckPhoneHomeHelper {
         }
         return Collections.emptyMap();
     }
-
 }

--- a/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
+++ b/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
@@ -84,7 +84,8 @@ public class BlackDuckPhoneHomeHelper {
         String blackDuckVersion = PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE;
 
         try {
-            BlackDuckServerData blackDuckServerData = blackDuckRegistrationService.getBlackDuckServerData();
+            boolean isAdminOperationAllowed = Boolean.parseBoolean(metaData.getOrDefault("isAdminOperationAllowed", "false"));
+            BlackDuckServerData blackDuckServerData = blackDuckRegistrationService.getBlackDuckServerData(isAdminOperationAllowed);
             registrationKey = blackDuckServerData.getRegistrationKey().orElse(PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE);
             blackDuckUrl = blackDuckServerData.getUrl().string();
             blackDuckVersion = blackDuckServerData.getVersion();

--- a/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
+++ b/src/main/java/com/blackduck/integration/blackduck/phonehome/BlackDuckPhoneHomeHelper.java
@@ -85,6 +85,7 @@ public class BlackDuckPhoneHomeHelper {
 
         try {
             boolean isAdminOperationAllowed = Boolean.parseBoolean(metaData.getOrDefault("isAdminOperationAllowed", "false"));
+            metaData.remove("isAdminOperationAllowed");
             BlackDuckServerData blackDuckServerData = blackDuckRegistrationService.getBlackDuckServerData(isAdminOperationAllowed);
             registrationKey = blackDuckServerData.getRegistrationKey().orElse(PhoneHomeRequestBody.UNKNOWN_FIELD_VALUE);
             blackDuckUrl = blackDuckServerData.getUrl().string();

--- a/src/main/java/com/blackduck/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
@@ -20,7 +20,6 @@ import com.blackduck.integration.blackduck.service.request.BlackDuckSingleReques
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.log.IntLogger;
 import com.blackduck.integration.rest.HttpUrl;
-import com.blackduck.integration.rest.exception.IntegrationRestException;
 
 public class BlackDuckRegistrationService extends DataService {
     private final UrlSingleResponse<RegistrationView> registrationResponse = apiDiscovery.metaRegistrationLink();
@@ -49,7 +48,6 @@ public class BlackDuckRegistrationService extends DataService {
         String registrationId = null;
         try {
             if (isRegistrationIdFetchAllowed()) {
-                // We need to wrap this because this will most likely fail unless they are running as an admin
                 registrationId = getRegistrationId();
             }
         } catch (IntegrationException e) {

--- a/src/main/java/com/blackduck/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/dataservice/BlackDuckRegistrationService.java
@@ -24,7 +24,6 @@ public class BlackDuckRegistrationService extends DataService {
     private final UrlSingleResponse<RegistrationView> registrationResponse = apiDiscovery.metaRegistrationLink();
     private final UrlSingleResponse<CurrentVersionView> currentVersionResponse = apiDiscovery.metaCurrentVersionLink();
     private final HttpUrl blackDuckUrl;
-    private static final ThreadLocal<Boolean> adminOperationAttempted = ThreadLocal.withInitial(() -> false);
 
     public BlackDuckRegistrationService(BlackDuckApiClient blackDuckApiClient, ApiDiscovery apiDiscovery, IntLogger logger, HttpUrl blackDuckUrl) {
         super(blackDuckApiClient, apiDiscovery, logger);
@@ -42,29 +41,22 @@ public class BlackDuckRegistrationService extends DataService {
         return registrationView.getRegistrationId();
     }
 
-    public BlackDuckServerData getBlackDuckServerData(boolean isAdmin) throws IntegrationException {
-        setAdminOperationAttempted(isAdmin);
+    public BlackDuckServerData getBlackDuckServerData() throws IntegrationException {
         CurrentVersionView currentVersionView = blackDuckApiClient.getResponse(currentVersionResponse);
         String registrationId = null;
         try {
-            if (shouldAttemptAdminOperations()) {
-                registrationId = getRegistrationId();
-            }
+            // We need to wrap this because this will most likely fail unless they are running as an admin
+            registrationId = getRegistrationId();
         } catch (IntegrationException e) {
-            logger.warn("Failed to fetch registration id: " + e.getMessage());
         }
         return new BlackDuckServerData(blackDuckUrl, currentVersionView.getVersion(), registrationId);
     }
 
-    public BlackDuckServerData getBlackDuckServerData() throws IntegrationException {
-        return getBlackDuckServerData(shouldAttemptAdminOperations());
-    }
-
-    private boolean shouldAttemptAdminOperations() {
-        return adminOperationAttempted.get();
-    }
-
-    private void setAdminOperationAttempted(boolean isAdmin) {
-        adminOperationAttempted.set(isAdmin);
+    public BlackDuckServerData getBlackDuckServerData(boolean isAdminOperationAllowed) throws IntegrationException {
+        if (isAdminOperationAllowed) {
+            return getBlackDuckServerData();
+        }
+        CurrentVersionView currentVersionView = blackDuckApiClient.getResponse(currentVersionResponse);
+        return new BlackDuckServerData(blackDuckUrl, currentVersionView.getVersion(), null);
     }
 }


### PR DESCRIPTION
**JIRA Ticket:**
IDETECT-4209

**Description:**
This merge request addresses the issue of excessive warning logs generated when non-admin users attempt to fetch the registration ID on the endpoint `/api/registration`. 
~The solution involves using a `ThreadLocal` variable to manage the state of whether the `getRegistrationId()` method has been called before or not by a non-syadmin user. This ensures that repeated attempts to fetch the registration ID are avoided, thereby significantly reducing unnecessary warning logs.~


**Update 1:**
`BlackDuckRegistrationService` has been refactored. Now, it follows an eager approach. `getBlackDuckServerData()` method has been overloaded to accept `isAdmin` boolean flag. ~The passed boolean `isAdmin` flag is stored in a static local variable.
Before calling `getRegistrationId()`, a check is done whether `isAdmin` is false and skip the call accordingly.~
This avoids unnecessary calls to the method `getRegistrationId()`, thus reducing excessive logs in hub webapp container due to call to the endpoint `/api/registration`.


**Update 2:**
In this update, the `getBlackDuckServerData()` method has been overloaded to accept a boolean flag `isAdminOperationAllowed`. This flag controls access to the `getRegistrationId()` method, which triggers a call to the `/api/registration` endpoint. To restrict this call, the flag should be set accordingly.

Detect can now pass this flag when invoking the method, as it determines the user's admin status during connectivity checks, retains it for the duration of the scan, and passes it during phone-home operations.

The original `getBlackDuckServerData()` method (with no arguments) has been retained for backward compatibility.

**_This fix is required for resolving the linked Detect issue._**