### PR TITLE
Update Project Version Request to include update metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.9-SNAPSHOT'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.9'
     api 'com.blackduck.integration:phone-home-client:7.0.0'
     api 'com.blackduck.integration:integration-bdio:27.0.0'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.8'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.9-SNAPSHOT'
     api 'com.blackduck.integration:phone-home-client:7.0.0'
     api 'com.blackduck.integration:integration-bdio:27.0.0'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 repositories {
     maven { url "${internalRepoHost}/artifactory/jcenter" }
     maven { url "https://repo.blackduck.com/bds-bdio-release" }
-    maven { url "https://repo.blackduck.com/artifactory/bds-integrations-snapshot/" }
+    maven { url "${SNPS_INTERNAL_ARTIFACTORY}/artifactory/bds-integrations-snapshot/" }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 repositories {
     maven { url "${internalRepoHost}/artifactory/jcenter" }
     maven { url "https://repo.blackduck.com/bds-bdio-release" }
-    maven { url "${SNPS_INTERNAL_ARTIFACTORY}/artifactory/bds-integrations-snapshot/" }
+    maven { url "${internalRepoHost}/artifactory/bds-integrations-snapshot/" }
 }
 
 dependencies {

--- a/src/main/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModel.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModel.java
@@ -49,6 +49,7 @@ public class ProjectSyncModel {
     public static final Field RELEASE_COMMENTS_FIELD = ProjectSyncModel.getFieldSafely("releaseComments");
     public static final Field RELEASED_ON_FIELD = ProjectSyncModel.getFieldSafely("releasedOn");
     public static final Field VERSION_NAME_FIELD = ProjectSyncModel.getFieldSafely("versionName");
+    public static final Field UPDATE_FIELD = ProjectSyncModel.getFieldSafely("update");
 
     // version license fields
     public static final Field VERSION_LICENSE_URL_FIELD = ProjectSyncModel.getFieldSafely("versionLicenseUrl");
@@ -71,6 +72,7 @@ public class ProjectSyncModel {
     private String releaseComments;
     private Date releasedOn;
     private String versionName;
+    private Boolean update;
 
     // version license fields
     private String versionLicenseUrl;
@@ -136,6 +138,7 @@ public class ProjectSyncModel {
         projectVersionRequest.setCloneFromReleaseUrl(cloneFromReleaseUrl);
         projectVersionRequest.setReleasedOn(releasedOn);
         projectVersionRequest.setNickname(nickname);
+        projectVersionRequest.setUpdate(update);
         if (fieldSet(ProjectSyncModel.VERSION_LICENSE_URL_FIELD)) {
             // A ProjectVersionRequest with a ComplexLicenseRequest that has a null license url triggers a failure
             projectVersionRequest.setLicense(createComplexLicenseRequest());
@@ -381,5 +384,14 @@ public class ProjectSyncModel {
     public void setVersionLicenseUrl(String versionLicenseUrl) {
         this.versionLicenseUrl = versionLicenseUrl;
         fieldsWithSetValues.add(ProjectSyncModel.VERSION_LICENSE_URL_FIELD);
+    }
+
+    public Boolean getUpdate() {
+        return update;
+    }
+
+    public void setUpdate(Boolean update) {
+        this.update = update;
+        fieldsWithSetValues.add(ProjectSyncModel.UPDATE_FIELD);
     }
 }

--- a/src/test/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModelTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModelTest.java
@@ -90,6 +90,7 @@ public class ProjectSyncModelTest {
         projectSyncModel.setReleaseComments("release comments");
         projectSyncModel.setReleasedOn(new Date());
         projectSyncModel.setVersionLicenseUrl("versionLicenseUrl");
+        projectSyncModel.setUpdate(true);
 
         assertFalse(((Set) setFields.get(projectSyncModel)).isEmpty());
         assertEquals(allFields, setFields.get(projectSyncModel));
@@ -128,6 +129,7 @@ public class ProjectSyncModelTest {
         projectSyncModel.setName("project name");
         projectSyncModel.setVersionName("version name");
         projectSyncModel.setPhase(ProjectVersionPhaseType.DEVELOPMENT);
+        projectSyncModel.setUpdate(true);
 
         ProjectRequest projectRequest = projectSyncModel.createProjectRequest();
         assertEquals("project name", projectRequest.getName());
@@ -144,6 +146,7 @@ public class ProjectSyncModelTest {
         assertEquals(releasedOn, projectRequest.getVersionRequest().getReleasedOn());
         assertEquals(ProjectVersionPhaseType.DEVELOPMENT, projectRequest.getVersionRequest().getPhase());
         assertEquals(ProjectVersionDistributionType.INTERNAL, projectRequest.getVersionRequest().getDistribution());
+        assertEquals(true, projectRequest.getVersionRequest().getUpdate());
     }
 
 }


### PR DESCRIPTION
To create and clone a project version at the same time, an update metadata field will be required to pass in the Project  Version creation request. Setting of that metadata takes place in bd-common.


Ticket: IDETECT-4671