### PR TITLE
Dev/shanty/idetect 4709 increase sleep interval policy caching

### DIFF
--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/ProjectBomServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/ProjectBomServiceTestIT.java
@@ -171,11 +171,15 @@ public class ProjectBomServiceTestIT {
         }
         policyRuleService.createPolicyRule(policyRule);
 
-        Thread.sleep(10000); // need this to give Black Duck enough time to check the project version against the policy rule
+        Thread.sleep(60000); // need this to give Black Duck enough time to check the project version against the policy rule
 
         // query projectBomService to see if project version has violated rule
         Optional<List<ProjectVersionPolicyRulesView>> activePolicies = projectBomService.getActivePoliciesForVersion(projectVersionView);
         Assertions.assertTrue(activePolicies.isPresent());
+
+        System.out.println("Active Policies Present: " + activePolicies.isPresent());
+        activePolicies.ifPresent(policies -> System.out.println("Policies Size: " + policies.size()));
+
         Assertions.assertFalse(activePolicies.get().isEmpty());
 
         Assertions.assertTrue(activePolicies.get().stream()

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/ProjectBomServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/ProjectBomServiceTestIT.java
@@ -177,9 +177,6 @@ public class ProjectBomServiceTestIT {
         Optional<List<ProjectVersionPolicyRulesView>> activePolicies = projectBomService.getActivePoliciesForVersion(projectVersionView);
         Assertions.assertTrue(activePolicies.isPresent());
 
-        System.out.println("Active Policies Present: " + activePolicies.isPresent());
-        activePolicies.ifPresent(policies -> System.out.println("Policies Size: " + policies.size()));
-
         Assertions.assertFalse(activePolicies.get().isEmpty());
 
         Assertions.assertTrue(activePolicies.get().stream()


### PR DESCRIPTION
Tested with two servers that are on 2025.4.1. The test passes with a server that has the policy rule caching interval to 1 minute (which I believe is the minimum). The test fails against valid03 (2025.4.1 but no property set)

Fix: 
1. increase sleep to 1 minute in test case and 
2. update relcandi's application.properties to include the following Blackduck config property: 
POLICY_RULE_PROPAGATION_CHECK_PERIOD_MINUTES=1

Closes IDETECT-4709 

