### PR TITLE
rev blackduck-common-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.9'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.12'
     api 'com.blackduck.integration:phone-home-client:7.0.0'
     api 'com.blackduck.integration:integration-bdio:27.0.0'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'


### PR DESCRIPTION
Brings in a new version of blackduck-common-api and its libraries to remove a vulnerability in Apache BeanUtils