### PR TITLE
Invoke signature scanner in SCASS mode

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -54,11 +54,12 @@ public class ScanBatch extends Stringable implements Buildable {
     private final String correlationId;
     private final String bomCompareMode;
     private final boolean csvArchive;
+    private final boolean scassScan;
 
     public ScanBatch(File outputDirectory, boolean cleanupOutput, int scanMemoryInMegabytes, boolean dryRun, boolean debug, boolean verbose,
         String scanCliOpts, String additionalScanArguments, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, HttpUrl blackDuckUrl,
         String blackDuckUsername, String blackDuckPassword, String blackDuckApiToken, ProxyInfo proxyInfo, boolean runInsecure, String projectName, String projectVersionName,
-        List<ScanTarget> scanTargets, boolean isRapid, ReducedPersistence reducedPersistence, @Nullable String correlationId, String bomCompareMode, boolean csvArchive) {
+        List<ScanTarget> scanTargets, boolean isRapid, ReducedPersistence reducedPersistence, @Nullable String correlationId, String bomCompareMode, boolean csvArchive, boolean scassScan) {
         this.outputDirectory = outputDirectory;
         this.cleanupOutput = cleanupOutput;
         this.scanMemoryInMegabytes = scanMemoryInMegabytes;
@@ -83,6 +84,7 @@ public class ScanBatch extends Stringable implements Buildable {
         this.correlationId = correlationId;
         this.bomCompareMode = bomCompareMode;
         this.csvArchive = csvArchive;
+        this.scassScan = scassScan;
     }
 
     /**
@@ -124,7 +126,7 @@ public class ScanBatch extends Stringable implements Buildable {
         ScanCommand scanCommand = new ScanCommand(signatureScannerInstallDirectory, commandOutputDirectory, commandDryRun, proxyInfo, scanCliOptsToUse, scanMemoryInMegabytes, commandScheme, commandHost,
             blackDuckApiToken, blackDuckUsername, blackDuckPassword, commandPort, runInsecure, scanTarget.getCodeLocationName(), blackDuckOnlineProperties,
             individualFileMatching, scanTarget.getExclusionPatterns(), additionalScanArguments, scanTarget.getPath(), verbose, debug, projectName, projectVersionName, isRapid, reducedPersistence, correlationId,
-            bomCompareMode, csvArchive);
+            bomCompareMode, csvArchive, scassScan);
         scanCommands.add(scanCommand);
     }
 

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatch.java
@@ -230,4 +230,8 @@ public class ScanBatch extends Stringable implements Buildable {
     public boolean isCsvArchive() {
     	return csvArchive;
     }
+    
+    public boolean isScassScan() {
+    	return scassScan;
+    }
 }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/ScanBatchBuilder.java
@@ -61,13 +61,14 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     private String bomCompareMode;
     
     private boolean csvArchive;
+	private boolean scassScan;
 
     @Override
     protected ScanBatch buildWithoutValidation() {
         BlackDuckOnlineProperties blackDuckOnlineProperties = new BlackDuckOnlineProperties(snippetMatching, uploadSource, licenseSearch, copyrightSearch);
         return new ScanBatch(outputDirectory, cleanupOutput, scanMemoryInMegabytes, dryRun, debug, verbose, scanCliOpts, additionalScanArguments,
             blackDuckOnlineProperties, individualFileMatching, blackDuckUrl, blackDuckUsername, blackDuckPassword, blackDuckApiToken, proxyInfo, alwaysTrustServerCertificate,
-            projectName, projectVersionName, scanTargets, isRapid, reducedPersistence, correlationId, bomCompareMode, csvArchive);
+            projectName, projectVersionName, scanTargets, isRapid, reducedPersistence, correlationId, bomCompareMode, csvArchive, scassScan);
     }
 
     @Override
@@ -382,6 +383,11 @@ public class ScanBatchBuilder extends IntegrationBuilder<ScanBatch> {
     
     public ScanBatchBuilder csvArchive(boolean csvArchive) {
     	this.csvArchive = csvArchive;
+    	return this;
+    }
+    
+    public ScanBatchBuilder scassScan(boolean scassScan) {
+    	this.scassScan = scassScan;
     	return this;
     }
 }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -157,7 +157,6 @@ public class ScanCommand {
             // only set it in this block.
             appendKeyValuePair("--no-persistence-mode", bomCompareMode);
         }
-        
 
         if (scassScan) {
             appendSingleArgument("--scass-scan");

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCommand.java
@@ -49,6 +49,7 @@ public class ScanCommand {
     private final String correlationId;
     private final String bomCompareMode;
     private final boolean csvArchive;
+    private final boolean scassScan;
 
     private List<String> command;
 
@@ -58,7 +59,7 @@ public class ScanCommand {
         String blackDuckUsername, String blackDuckPassword, int port, boolean runInsecure, String name, BlackDuckOnlineProperties blackDuckOnlineProperties, IndividualFileMatching individualFileMatching, Set<String> excludePatterns,
         String additionalScanArguments, String targetPath, boolean verbose, boolean debug, String projectName, String versionName, boolean isRapid,
         ReducedPersistence reducedPersistence,
-        @Nullable String correlationId, String bomCompareMode, boolean csvArchive) {
+        @Nullable String correlationId, String bomCompareMode, boolean csvArchive, boolean scassScan) {
         this.signatureScannerInstallDirectory = signatureScannerInstallDirectory;
         this.outputDirectory = outputDirectory;
         this.dryRun = dryRun;
@@ -87,6 +88,7 @@ public class ScanCommand {
         this.correlationId = correlationId;
         this.bomCompareMode = bomCompareMode;
         this.csvArchive = csvArchive;
+        this.scassScan = scassScan;
     }
 
     public List<String> createCommandForProcessBuilder(IntLogger logger, ScanPaths scannerPaths, String specificRunOutputDirectoryPath) throws IllegalArgumentException, IntegrationException {
@@ -154,6 +156,11 @@ public class ScanCommand {
             // --no-persistence-mode should never be used without --no-persistence so
             // only set it in this block.
             appendKeyValuePair("--no-persistence-mode", bomCompareMode);
+        }
+        
+
+        if (scassScan) {
+            appendSingleArgument("--scass-scan");
         }
 
         populateReducedPersistence();


### PR DESCRIPTION
This new option allows for calling the signature scanner in SCASS mode. This will result in SCASS laying down the BDIO on disk so that it can be uploaded by other utilities, like Detect, instead of sending the BDIO itself to hub directly. This is for online mode. Offline mode will still happen as before.