### PR TITLE
Pass OS architecture from Detect

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -37,6 +37,7 @@ import java.security.cert.Certificate;
 public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     // The tools API for downloading the scan-cli is called on by Detect for BD versions 2024.7.0 or newer
     public static final BlackDuckVersion MIN_BLACK_DUCK_VERSION = new BlackDuckVersion(2024, 7, 0);
+    public static final BlackDuckVersion MIN_ARM_BLACK_DUCK_VERSION = new BlackDuckVersion(2025, 7, 0);
 
     private static final String LATEST_SCAN_CLI_TOOL_DOWNLOAD_URL = "api/tools/scan.cli.zip/versions/latest/";
     private static final String PLATFORM_PARAMETER_KEY = "platforms";

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -23,7 +23,6 @@ import com.blackduck.integration.util.CleanupZipExpander;
 import com.blackduck.integration.util.OperatingSystemType;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.SystemUtils;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
@@ -57,6 +56,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     private final HttpUrl blackDuckServerUrl;
     private final OperatingSystemType operatingSystemType;
     private final File installDirectory;
+    private final String osArchitecture;
 
     public ToolsApiScannerInstaller(
             IntLogger logger,
@@ -66,7 +66,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             KeyStoreHelper keyStoreHelper,
             HttpUrl blackDuckServerUrl,
             OperatingSystemType operatingSystemType,
-            File installDirectory
+            File installDirectory,
+            String osArchitecture
     ) {
         if (null == blackDuckServerUrl) {
             throw new IllegalArgumentException("A Black Duck server url must be provided.");
@@ -80,6 +81,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
         this.blackDuckServerUrl = blackDuckServerUrl;
         this.operatingSystemType = operatingSystemType;
         this.installDirectory = installDirectory;
+        this.osArchitecture = osArchitecture;
     }
 
     /**
@@ -159,7 +161,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             platform = LINUX_PLATFORM_PARAMETER_VALUE;
         }
 
-        if (SystemUtils.OS_ARCH.equals("aarch64") || SystemUtils.OS_ARCH.equals("arm64")) {
+        if (osArchitecture.equals("aarch64") || osArchitecture.equals("arm64")) {
             platform = platform + "_arm64";
         }
 

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/ToolsApiScannerInstallerTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/ToolsApiScannerInstallerTestIT.java
@@ -19,6 +19,7 @@ import com.blackduck.integration.util.IntEnvironmentVariables;
 import com.blackduck.integration.util.OperatingSystemType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,8 @@ public class ToolsApiScannerInstallerTestIT {
                 new KeyStoreHelper(logger),
                 blackDuckServerUrl,
                 operatingSystemType,
-                scannerInstallationDirectory);
+                scannerInstallationDirectory,
+                SystemUtils.OS_ARCH);
         toolsApiScannerInstaller.installOrUpdateScanner();
 
         ScanPaths scanPaths = scanPathsUtility.searchForScanPaths(scannerInstallationDirectory);


### PR DESCRIPTION
This PR fixes a bug where we do not want to use the new endpoints for HUB versions 2025.4.0 or below. To achieve that, we will check the HUB version on detect side and then pass the architecture based on the result. Essentially, we do not want to pass `arm64` in case where HUB is below required version.