### PR TITLE
Add scanCliArchitecture file for tracking architecture downloaded during previous runs

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 public abstract class ApiScannerInstaller implements ScannerInstaller {
     public static final String BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY = "Black_Duck_Scan_Installation";
     public static final String VERSION_FILENAME = "blackDuckVersion.txt";
+    public static final String ARCHITECTURE_FILENAME = "scanCliArchitecture.txt";
 
     @Override
     public abstract File installOrUpdateScanner() throws BlackDuckIntegrationException;

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 public abstract class ApiScannerInstaller implements ScannerInstaller {
     public static final String BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY = "Black_Duck_Scan_Installation";
     public static final String VERSION_FILENAME = "blackDuckVersion.txt";
-    public static final String ARCHITECTURE_FILENAME = "scanCliArchitecture.txt";
-    public static final String ARCHITECTURE_FILE_DIRECTORY = "Scan_CLI_Architecture";
 
     @Override
     public abstract File installOrUpdateScanner() throws BlackDuckIntegrationException;

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
@@ -19,6 +19,7 @@ public abstract class ApiScannerInstaller implements ScannerInstaller {
     public static final String BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY = "Black_Duck_Scan_Installation";
     public static final String VERSION_FILENAME = "blackDuckVersion.txt";
     public static final String ARCHITECTURE_FILENAME = "scanCliArchitecture.txt";
+    public static final String ARCHITECTURE_FILE_DIRECTORY = "Scan_CLI_Architecture";
 
     @Override
     public abstract File installOrUpdateScanner() throws BlackDuckIntegrationException;

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
@@ -36,6 +36,7 @@ public class ScanPathsUtility {
     private static final String OTHER_JAVA_PATH = String.format(JAVA_PATH_FORMAT, "java");
     private static final String CACERTS_PATH = "lib" + File.separator + "security" + File.separator + "cacerts";
     private static final String STANDALONE_JAR_PATH = "cache" + File.separator + "scan.cli.impl-standalone.jar";
+    public static final String ARCHITECTURE_FILENAME = "scanCliArchitecture.txt";
 
     private static final FileFilter EXCLUDE_NON_SCAN_CLI_DIRECTORIES_FILTER = file -> !file.isHidden() && !file.getName().contains("windows") && file.isDirectory();
     private static final FileFilter JRE_DIRECTORY_FILTER = file -> "jre".equalsIgnoreCase(file.getName()) && file.isDirectory();
@@ -49,6 +50,8 @@ public class ScanPathsUtility {
     private final IntEnvironmentVariables intEnvironmentVariables;
     private final OperatingSystemType operatingSystemType;
 
+    private File architectureFile;
+    
     public ScanPathsUtility(final IntLogger logger, final IntEnvironmentVariables intEnvironmentVariables, final OperatingSystemType operatingSystemType) {
         this.logger = logger;
         this.intEnvironmentVariables = intEnvironmentVariables;
@@ -83,6 +86,8 @@ public class ScanPathsUtility {
         } else {
             logger.debug(String.format("The directory structure was likely created manually - be sure the jre folder exists in: %s", installDirectory.getAbsolutePath()));
         }
+
+        architectureFile = new File(installDirectory, ARCHITECTURE_FILENAME); 
 
         final File jreContentsDirectory = findFirstFilteredFile(installDirectory, JRE_DIRECTORY_FILTER, "Could not find the 'jre' directory in %s.");
 
@@ -217,6 +222,10 @@ public class ScanPathsUtility {
         }
 
         return javaHomeSupplier.get();
+    }
+
+    public File getArchitectureFile() {
+        return architectureFile;
     }
 
 }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -133,7 +133,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             // Initiate a fresh download and update architecture value in file
             if(!localArchitecture.equals(osArchitecture)) {
                 localScannerVersion = "";
-                FileUtils.writeStringToFile(versionFile, osArchitecture, Charset.defaultCharset());
+                FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
             }
 
             logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -99,7 +99,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
                 ScanPaths scanPaths = scanPathsUtility.searchForScanPaths(installDirectory);
                 if (!scanPaths.isManagedByLibrary()) {
                     return installDirectory;
-                }
+                }         
             } catch (BlackDuckIntegrationException ignored) {
                 // a valid scanPaths could not be found so we will need to attempt an install
             }
@@ -107,11 +107,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
 
         File scannerExpansionDirectory = new File(installDirectory, BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
         scannerExpansionDirectory.mkdirs();
-
+        File architectureFile = scanPathsUtility.getArchitectureFile();
         File versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
-        File architectureDirectory = new File(installDirectory, ARCHITECTURE_FILE_DIRECTORY);
-        architectureDirectory.mkdirs();
-        File architectureFile = new File(architectureDirectory, ARCHITECTURE_FILENAME);
         HttpUrl downloadUrl = getDownloadUrl();
 
         try {
@@ -123,6 +120,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
                 logger.debug("The version file has not been created yet so creating it now.");
                 FileUtils.writeStringToFile(versionFile, scannerVersion, Charset.defaultCharset());
                 // Creating the architecture file for storing the last downloaded scan cli architecture value
+                // The architecture file needs to be re-initialized since the scan-cli directory was newly created in above step
+                architectureFile = scanPathsUtility.getArchitectureFile();
                 FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
                 return installDirectory;
             }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -109,7 +109,9 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
         scannerExpansionDirectory.mkdirs();
 
         File versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
-        File architectureFile = new File(scannerExpansionDirectory, ARCHITECTURE_FILENAME);
+        File architectureDirectory = new File(installDirectory, ARCHITECTURE_FILE_DIRECTORY);
+        architectureDirectory.mkdirs();
+        File architectureFile = new File(architectureDirectory, ARCHITECTURE_FILENAME);
         HttpUrl downloadUrl = getDownloadUrl();
 
         try {
@@ -139,12 +141,10 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             // We will call the tool download API and update our local signature scanner only if it happens to be outdated.
             scannerVersion = downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, localScannerVersion);
             // Update version file if needed
-            if (localScannerVersion != scannerVersion) {
+            if (!localScannerVersion.equals(scannerVersion)) {
                 FileUtils.writeStringToFile(versionFile, scannerVersion, Charset.defaultCharset());
             }
-            if(!localArchitecture.equals(osArchitecture)) {
-                FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
-            }
+            FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
         } catch (Exception e) {
             throw new BlackDuckIntegrationException("The Black Duck Signature Scanner could not be downloaded successfully: " + e.getMessage(), e);
         }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -133,7 +133,6 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             // Initiate a fresh download and update architecture value in file
             if(!localArchitecture.equals(osArchitecture)) {
                 localScannerVersion = "";
-                FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
             }
 
             logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));
@@ -142,6 +141,9 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             // Update version file if needed
             if (localScannerVersion != scannerVersion) {
                 FileUtils.writeStringToFile(versionFile, scannerVersion, Charset.defaultCharset());
+            }
+            if(!localArchitecture.equals(osArchitecture)) {
+                FileUtils.writeStringToFile(architectureFile, osArchitecture, Charset.defaultCharset());
             }
         } catch (Exception e) {
             throw new BlackDuckIntegrationException("The Black Duck Signature Scanner could not be downloaded successfully: " + e.getMessage(), e);

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -130,8 +130,10 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
             // An architecture file exists, so we will compare the architecture to determine if a download should occur
             String localArchitecture = FileUtils.readFileToString(architectureFile, Charset.defaultCharset());
 
+            // Initiate a fresh download and update architecture value in file
             if(!localArchitecture.equals(osArchitecture)) {
                 localScannerVersion = "";
+                FileUtils.writeStringToFile(versionFile, osArchitecture, Charset.defaultCharset());
             }
 
             logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/ToolsApiScannerInstallerTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/ToolsApiScannerInstallerTestIT.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 
 import static com.blackduck.integration.blackduck.codelocation.signaturescanner.command.ApiScannerInstaller.BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY;
 import static com.blackduck.integration.blackduck.codelocation.signaturescanner.command.ApiScannerInstaller.VERSION_FILENAME;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -53,14 +54,29 @@ public class ToolsApiScannerInstallerTestIT {
     @Test
     void testFreshDownload_followedByAnUpdate() throws Exception {
         setUp();
-        downloadSignatureScanner();
+        downloadSignatureScanner(SystemUtils.OS_ARCH, false);
         // Tweak version file so we pretend the installed version in part 1 of this test is a lower major version than the BD server this the test is actually connected to
         incrementMajorVersionOfInstalledSignatureScanner();
         // Attempt a subsequent download request that will upgrade always
-        downloadSignatureScanner();
+        downloadSignatureScanner(SystemUtils.OS_ARCH, false);
     }
 
-    private void downloadSignatureScanner() throws BlackDuckIntegrationException {
+    @Test
+    void testFreshDownload_followedByArchitectureUpdate() throws Exception {
+        setUp();
+        downloadSignatureScanner(SystemUtils.OS_ARCH, false);
+        String osArchitecture;
+        if(SystemUtils.OS_ARCH.equals("aarch64")) {
+            osArchitecture = "amd64";
+        } else {
+            osArchitecture = "aarch64";
+        }
+
+        // Attempt a subsequent download request that will upgrade always as architecture was changed
+        downloadSignatureScanner(osArchitecture, true);
+    }
+
+    private void downloadSignatureScanner(String osArchitecture, boolean checkArchitectureUpdate) throws BlackDuckIntegrationException {
         IntLogger logger = new BufferedIntLogger();
 
         BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = intHttpClientTestHelper.getBlackDuckServerConfigBuilder();
@@ -83,7 +99,7 @@ public class ToolsApiScannerInstallerTestIT {
                 blackDuckServerUrl,
                 operatingSystemType,
                 scannerInstallationDirectory,
-                SystemUtils.OS_ARCH);
+                osArchitecture);
         toolsApiScannerInstaller.installOrUpdateScanner();
 
         ScanPaths scanPaths = scanPathsUtility.searchForScanPaths(scannerInstallationDirectory);
@@ -94,6 +110,18 @@ public class ToolsApiScannerInstallerTestIT {
         assertTrue(new File(scanPaths.getPathToJavaExecutable()).canExecute());
         assertTrue(new File(scanPaths.getPathToOneJar()).canExecute());
         assertTrue(new File(scanPaths.getPathToScanExecutable()).canExecute());
+
+        assertTrue(scanPathsUtility.getArchitectureFile().exists());
+
+        if(checkArchitectureUpdate) {
+            File archFile = scanPathsUtility.getArchitectureFile();
+            try {
+                String arch = FileUtils.readFileToString(archFile, Charset.defaultCharset());
+                assertFalse(arch.equals(SystemUtils.OS_ARCH));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds a new architecture file along with version file in the same location where scan cli is stored. This will handle the case when arm64 users will try to upgrade from 10.6.0 to 10.7.0 version of Detect and have locally cached scan cli. Currently there is no way for Detect to differentiate the architecture between old and new scan cli for us to be able to update the locally stored scan cli.

There are two new conditions when fresh download will get triggered, if the architecture file does not exist and if it exists the current osArchitecture value is not equal to the one stored in file. Please let me know if there are some conditions which I am missing.