### PR TITLE
Add support for new metadata.json file in new scan-cli

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ApiScannerInstaller.java
@@ -24,6 +24,6 @@ public abstract class ApiScannerInstaller implements ScannerInstaller {
 
     protected abstract HttpUrl getDownloadUrl() throws BlackDuckIntegrationException;
 
-    protected abstract String downloadSignatureScanner(File scannerExpansionDirectory, HttpUrl downloadUrl, String localScannerVersion) throws IOException, IntegrationException, ArchiveException;
+    protected abstract Object downloadSignatureScanner(File scannerExpansionDirectory, HttpUrl downloadUrl, String localScannerVersion) throws IOException, IntegrationException, ArchiveException;
 
 }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCliMetadata.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanCliMetadata.java
@@ -1,0 +1,95 @@
+package com.blackduck.integration.blackduck.codelocation.signaturescanner.command;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ScanCliMetadata {
+    @SerializedName("documentVersion")
+    private String documentVersion;
+    
+    @SerializedName("toolVersion")
+    private String toolVersion;
+    
+    @SerializedName("os")
+    private String os;
+    
+    @SerializedName("arch")
+    private String arch;
+    
+    // Default constructor
+    public ScanCliMetadata() {
+    }
+    
+    // Constructor with all fields
+    public ScanCliMetadata(String documentVersion, String toolVersion, String os, String arch) {
+        this.documentVersion = documentVersion;
+        this.toolVersion = toolVersion;
+        this.os = os;
+        this.arch = arch;
+    }
+    
+    // Getters
+    public String getDocumentVersion() {
+        return documentVersion;
+    }
+    
+    public String getToolVersion() {
+        return toolVersion;
+    }
+    
+    public String getOs() {
+        return os;
+    }
+    
+    public String getArch() {
+        return arch;
+    }
+    
+    // Setters
+    public void setDocumentVersion(String documentVersion) {
+        this.documentVersion = documentVersion;
+    }
+    
+    public void setToolVersion(String toolVersion) {
+        this.toolVersion = toolVersion;
+    }
+    
+    public void setOs(String os) {
+        this.os = os;
+    }
+    
+    public void setArch(String arch) {
+        this.arch = arch;
+    }
+    
+    /**
+     * Reads metadata from a JSON file and deserializes it to a ScanCliMetadata object.
+     * The JSON file should contain an array with a single metadata object.
+     * 
+     * @param metadataFile The metadata JSON file to read
+     * @return ScanCliMetadata object containing the deserialized data
+     * @throws IOException if there's an error reading the file
+     */
+    public static ScanCliMetadata getMetadata(File metadataFile) throws IOException {
+        Gson gson = new Gson();
+        
+        try (FileReader reader = new FileReader(metadataFile)) {
+            // The JSON file contains an array with a single metadata object
+            Type listType = new TypeToken<List<ScanCliMetadata>>(){}.getType();
+            List<ScanCliMetadata> metadataList = gson.fromJson(reader, listType);
+            
+            if (metadataList != null && !metadataList.isEmpty()) {
+                return metadataList.get(0);
+            } else {
+                throw new IOException("No metadata found in the file or file is empty");
+            }
+        }
+    }
+}

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
@@ -43,7 +43,6 @@ public class ScanPathsUtility {
     private static final FileFilter JRE_DIRECTORY_FILTER = file -> "jre".equalsIgnoreCase(file.getName()) && file.isDirectory();
     private static final FileFilter LIB_DIRECTORY_FILTER = file -> "lib".equalsIgnoreCase(file.getName()) && file.isDirectory();
     private static final FileFilter SCAN_CLI_JAR_FILE_FILTER = file -> file.getName().startsWith("scan.cli") && file.getName().endsWith(".jar") && file.isFile();
-    private static final FileFilter METADATA_FILE_FILTER = file -> file.getName().equals(METADATA_FILE_NAME);
 
     // this will allow for multiple threads to always get a unique number
     private final AtomicInteger defaultMultiThreadingId = new AtomicInteger(0);

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
@@ -12,6 +12,7 @@ import com.blackduck.integration.function.ThrowingSupplier;
 import com.blackduck.integration.log.IntLogger;
 import com.blackduck.integration.util.IntEnvironmentVariables;
 import com.blackduck.integration.util.OperatingSystemType;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,11 +37,13 @@ public class ScanPathsUtility {
     private static final String OTHER_JAVA_PATH = String.format(JAVA_PATH_FORMAT, "java");
     private static final String CACERTS_PATH = "lib" + File.separator + "security" + File.separator + "cacerts";
     private static final String STANDALONE_JAR_PATH = "cache" + File.separator + "scan.cli.impl-standalone.jar";
+    private static final String METADATA_FILE_NAME = "metadata.json";
 
     private static final FileFilter EXCLUDE_NON_SCAN_CLI_DIRECTORIES_FILTER = file -> !file.isHidden() && !file.getName().contains("windows") && file.isDirectory();
     private static final FileFilter JRE_DIRECTORY_FILTER = file -> "jre".equalsIgnoreCase(file.getName()) && file.isDirectory();
     private static final FileFilter LIB_DIRECTORY_FILTER = file -> "lib".equalsIgnoreCase(file.getName()) && file.isDirectory();
     private static final FileFilter SCAN_CLI_JAR_FILE_FILTER = file -> file.getName().startsWith("scan.cli") && file.getName().endsWith(".jar") && file.isFile();
+    private static final FileFilter METADATA_FILE_FILTER = file -> file.getName().equals(METADATA_FILE_NAME);
 
     // this will allow for multiple threads to always get a unique number
     private final AtomicInteger defaultMultiThreadingId = new AtomicInteger(0);
@@ -48,6 +51,8 @@ public class ScanPathsUtility {
     private final IntLogger logger;
     private final IntEnvironmentVariables intEnvironmentVariables;
     private final OperatingSystemType operatingSystemType;
+
+    private File scanCliMetadataFile;
 
     public ScanPathsUtility(final IntLogger logger, final IntEnvironmentVariables intEnvironmentVariables, final OperatingSystemType operatingSystemType) {
         this.logger = logger;
@@ -94,6 +99,8 @@ public class ScanPathsUtility {
 
         final String pathToOneJar = findPathToStandaloneJar(libDirectory);
         final String pathToScanExecutable = findPathToScanCliJar(libDirectory);
+
+        scanCliMetadataFile = findFirstFilteredFile(installDirectory, METADATA_FILE_FILTER, "Could not find the metadata file in %s");
 
         return new ScanPaths(pathToJavaExecutable, pathToCacerts, pathToOneJar, pathToScanExecutable, managedByLibrary);
     }
@@ -219,4 +226,7 @@ public class ScanPathsUtility {
         return javaHomeSupplier.get();
     }
 
+    public File getMetadataFile() {
+        return scanCliMetadataFile;
+    }
 }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ScanPathsUtility.java
@@ -100,8 +100,8 @@ public class ScanPathsUtility {
         final String pathToOneJar = findPathToStandaloneJar(libDirectory);
         final String pathToScanExecutable = findPathToScanCliJar(libDirectory);
 
-        scanCliMetadataFile = findFirstFilteredFile(installDirectory, METADATA_FILE_FILTER, "Could not find the metadata file in %s");
-
+        scanCliMetadataFile = new File(installDirectory, METADATA_FILE_NAME);
+    
         return new ScanPaths(pathToJavaExecutable, pathToCacerts, pathToOneJar, pathToScanExecutable, managedByLibrary);
     }
 

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -124,6 +124,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
                 String localScannerVersion = scanCliMetadata.getToolVersion();
                 
                 String localArchitecture = scanCliMetadata.getArch();
+
+                // Doing the check to see if the current expected architecture value and the already existing architecture mismatch, if it does setting the version to empty triggers a fresh download
                 if (localArchitecture.equals(ARM64_CONSTANT)) {
                     if (!osArchitecture.equals(AARCH64_CONSTANT) && !osArchitecture.equals(ARM64_CONSTANT)) {
                         localScannerVersion = "";
@@ -163,6 +165,8 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     }
 
     private boolean checkOSValue(String os) {
+
+        // Doing the check to see if the current expected os value and the already existing os mismatch, if it does setting the version to empty triggers a fresh download
 
         if (os.equals(MAC_PLATFORM_PARAMETER_VALUE) && !operatingSystemType.equals(OperatingSystemType.MAC)) {
             return false;

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -22,12 +22,14 @@ import com.blackduck.integration.rest.response.Response;
 import com.blackduck.integration.util.CleanupZipExpander;
 import com.blackduck.integration.util.OperatingSystemType;
 import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.io.FileUtils;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.Certificate;
@@ -59,6 +61,7 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     private final OperatingSystemType operatingSystemType;
     private final File installDirectory;
     private final String osArchitecture;
+    private File versionFile;
 
     public ToolsApiScannerInstaller(
             IntLogger logger,
@@ -109,56 +112,48 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
         File scannerExpansionDirectory = new File(installDirectory, BLACK_DUCK_SIGNATURE_SCANNER_INSTALL_DIRECTORY);
         scannerExpansionDirectory.mkdirs();
 
+        versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
         HttpUrl downloadUrl = getDownloadUrl();
 
         File scanCliMetadataFile = scanPathsUtility.getMetadataFile();
 
         try {
-            ScanCliMetadata scanCliMetadata;
-            if (scanCliMetadataFile == null || !scanCliMetadataFile.exists()) {
-                logger.info("No metadata file exists, assuming this is new installation and the signature scanner should be downloaded.");
-                scanCliMetadataFile = downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, "");
-               
-                // Delete version file if needed for upgrade scenario, since we do not delete files under that directory
-                // TODO delete this section once we reach end of support for 10.6.0 and below versions
-
-                File versionFile = new File(scannerExpansionDirectory, VERSION_FILENAME);
-                if (versionFile.exists()) {
-                    boolean deleted = versionFile.delete();
-                    if (!deleted) {
-                        logger.warn("Failed to delete version file: " + versionFile.getAbsolutePath());
-                    } else {
-                        logger.debug("Successfully deleted version file: " + versionFile.getAbsolutePath());
+            if (scanCliMetadataFile != null && scanCliMetadataFile.exists()) {
+                ScanCliMetadata scanCliMetadata = ScanCliMetadata.getMetadata(scanCliMetadataFile);
+                // determine last version from the file
+                String localScannerVersion = scanCliMetadata.getToolVersion();
+                
+                String localArchitecture = scanCliMetadata.getArch();
+                if (localArchitecture.equals(ARM64_CONSTANT)) {
+                    if (!osArchitecture.equals(AARCH64_CONSTANT) && !osArchitecture.equals(ARM64_CONSTANT)) {
+                        localScannerVersion = "";
+                    }
+                } else if (localArchitecture.equals(X64_CONSTANT)) {
+                    if (osArchitecture.equals(AARCH64_CONSTANT) || osArchitecture.equals(ARM64_CONSTANT)) {
+                        localScannerVersion = "";
                     }
                 }
 
-                return installDirectory;
-            }
+                String os = scanCliMetadata.getOs();
 
-            scanCliMetadata = ScanCliMetadata.getMetadata(scanCliMetadataFile);
-            // determine last version from the file
-            String localScannerVersion = scanCliMetadata.getToolVersion();
-            
-            String localArchitecture = scanCliMetadata.getArch();
-            if (localArchitecture.equals(ARM64_CONSTANT)) {
-                if (!osArchitecture.equals(AARCH64_CONSTANT) && !osArchitecture.equals(ARM64_CONSTANT)) {
+                if(!checkOSValue(os)) {
                     localScannerVersion = "";
                 }
-            } else if (localArchitecture.equals(X64_CONSTANT)) {
-                if (osArchitecture.equals(AARCH64_CONSTANT) || osArchitecture.equals(ARM64_CONSTANT)) {
-                    localScannerVersion = "";
-                }
+
+                logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));
+                // We will call the tool download API and update our local signature scanner only if it happens to be outdated
+                scanCliMetadataFile = downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, localScannerVersion);
+            } else if (versionFile.exists()) {
+                //TODO delete this file when Detect 10.6.0 and lower reach end of support
+                // A version file exists, so we have to compare to determine if a download should occur.
+                String localScannerVersion = FileUtils.readFileToString(versionFile, Charset.defaultCharset());
+                logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));
+
+                downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, localScannerVersion);
+            } else {
+                logger.info("No metadata file exists, assuming this is new installation and the signature scanner should be downloaded.");
+                scanCliMetadataFile = downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, "");
             }
-
-            String os = scanCliMetadata.getOs();
-
-            if(!checkOSValue(os)) {
-                localScannerVersion = "";
-            }
-
-            logger.debug(String.format("Locally installed signature scanner version: %s", localScannerVersion));
-            // We will call the tool download API and update our local signature scanner only if it happens to be outdated
-            scanCliMetadataFile = downloadSignatureScanner(scannerExpansionDirectory, downloadUrl, localScannerVersion);
         } catch (Exception e) {
             throw new BlackDuckIntegrationException("The Black Duck Signature Scanner could not be downloaded successfully: " + e.getMessage(), e);
         }
@@ -296,6 +291,9 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
 
 
                 connectAndGetServerCertificate(downloadUrl, scanPaths);
+
+                //TODO delete this file when Detect 10.6.0 and lower reach end of support
+                FileUtils.writeStringToFile(versionFile, latestScannerVersion, Charset.defaultCharset());
 
                 logger.info("Black Duck Signature Scanner downloaded successfully.");
                 return scanPathsUtility.getMetadataFile();


### PR DESCRIPTION
This PR takes in a new metadata.json file which is packaged with new scan cli. This will handle the case when arm64 users will try to upgrade from 10.6.0 to 10.7.0 version of Detect and have locally cached scan cli. Currently there is no way for Detect to differentiate the architecture between old and new scan cli for us to be able to update the locally stored scan cli.

There are new conditions when fresh download will get triggered, if the metadata file does not exist and if it exists the current osArchitecture value is not equal to the one stored in file and also checks if the os value is different from the expected one.