### PR TITLE
Add deep license data to project objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.12'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.13'
     api 'com.blackduck.integration:phone-home-client:7.0.1'
     api 'com.blackduck.integration:integration-bdio:27.0.4'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'

--- a/src/main/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModel.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModel.java
@@ -34,6 +34,8 @@ public class ProjectSyncModel {
     // project fields
     public static final Field CLONE_CATEGORIES_FIELD = ProjectSyncModel.getFieldSafely("cloneCategories");
     public static final Field CUSTOM_SIGNATURE_ENABLED_FIELD = ProjectSyncModel.getFieldSafely("customSignatureEnabled");
+    public static final Field DEEP_LICENSE_DATA_ENABLED_FIELD = ProjectSyncModel.getFieldSafely("deepLicenseDataEnabled");
+    public static final Field DEEP_LICENSE_DATA_SNIPPET_ENABLED_FIELD = ProjectSyncModel.getFieldSafely("deepLicenseDataSnippetEnabled");
     public static final Field DESCRIPTION_FIELD = ProjectSyncModel.getFieldSafely("description");
     public static final Field NAME_FIELD = ProjectSyncModel.getFieldSafely("name");
     public static final Field PROJECT_LEVEL_ADJUSTMENTS_FIELD = ProjectSyncModel.getFieldSafely("projectLevelAdjustments");
@@ -57,6 +59,8 @@ public class ProjectSyncModel {
     // project fields
     private List<ProjectCloneCategoriesType> cloneCategories;
     private Boolean customSignatureEnabled;
+    private Boolean deepLicenseDataEnabled;
+    private Boolean deepLicenseDataSnippetEnabled;
     private String description;
     private String name;
     private Boolean projectLevelAdjustments;
@@ -123,6 +127,8 @@ public class ProjectSyncModel {
         projectRequest.setProjectGroup(projectGroup);
         projectRequest.setCloneCategories(cloneCategories);
         projectRequest.setCustomSignatureEnabled(customSignatureEnabled);
+        projectRequest.setDeepLicenseDataEnabled(deepLicenseDataEnabled);
+        projectRequest.setDeepLicenseDataSnippetEnabled(deepLicenseDataSnippetEnabled);
 
         projectRequest.setVersionRequest(createProjectVersionRequest());
 
@@ -162,6 +168,14 @@ public class ProjectSyncModel {
             projectView.setCustomSignatureEnabled(customSignatureEnabled);
         }
 
+        if (fieldSet(ProjectSyncModel.DEEP_LICENSE_DATA_ENABLED_FIELD)) {
+            projectView.setDeepLicenseDataEnabledEnabled(deepLicenseDataEnabled);
+        }
+        
+        if (fieldSet(ProjectSyncModel.DEEP_LICENSE_DATA_SNIPPET_ENABLED_FIELD)) {
+            projectView.setDeepLicenseDataSnippetEnabled(deepLicenseDataSnippetEnabled);
+        }
+        
         if (fieldSet(ProjectSyncModel.DESCRIPTION_FIELD)) {
             projectView.setDescription(description);
         }
@@ -254,6 +268,24 @@ public class ProjectSyncModel {
     public void setCustomSignatureEnabled(Boolean customSignatureEnabled) {
         this.customSignatureEnabled = customSignatureEnabled;
         fieldsWithSetValues.add(ProjectSyncModel.CUSTOM_SIGNATURE_ENABLED_FIELD);
+    }
+    
+    public Boolean getDeepLicenseDataEnabled() {
+        return deepLicenseDataEnabled;
+    }
+
+    public void setDeepLicenseDataEnabledEnabled(Boolean deepLicenseDataEnabled) {
+        this.deepLicenseDataEnabled = deepLicenseDataEnabled;
+        fieldsWithSetValues.add(ProjectSyncModel.DEEP_LICENSE_DATA_ENABLED_FIELD);
+    }
+    
+    public Boolean getDeepLicenseDataSnippetEnabled() {
+        return deepLicenseDataSnippetEnabled;
+    }
+
+    public void setDeepLicenseDataSnippetEnabled(Boolean deepLicenseDataSnippetEnabled) {
+        this.deepLicenseDataSnippetEnabled = deepLicenseDataSnippetEnabled;
+        fieldsWithSetValues.add(ProjectSyncModel.DEEP_LICENSE_DATA_SNIPPET_ENABLED_FIELD);
     }
 
     public String getDescription() {

--- a/src/test/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModelTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/service/model/ProjectSyncModelTest.java
@@ -91,6 +91,8 @@ public class ProjectSyncModelTest {
         projectSyncModel.setReleasedOn(new Date());
         projectSyncModel.setVersionLicenseUrl("versionLicenseUrl");
         projectSyncModel.setUpdate(true);
+        projectSyncModel.setDeepLicenseDataEnabledEnabled(true);
+        projectSyncModel.setDeepLicenseDataSnippetEnabled(true);
 
         assertFalse(((Set) setFields.get(projectSyncModel)).isEmpty());
         assertEquals(allFields, setFields.get(projectSyncModel));


### PR DESCRIPTION
This work adds getters and setters on project related POJO objects to store information regarding deep license enablement.

This can be used by upstream clients when creating Black Duck projects if they wish to set these deep license fields.